### PR TITLE
Add chat interfaces, WebSocket streaming, and conversational prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+*.tmp

--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# Mistria AI
+
+An adaptive AI companion chatbot powered by Ollama, with a dynamic pulse system that adjusts conversation intensity based on user interaction.
+
+## Prerequisites
+
+- **Python 3.12+**
+- **Ollama** — download from [ollama.com/download](https://ollama.com/download)
+
+## Setup
+
+```bash
+# Clone and enter the project
+git clone https://github.com/vatsal1306/mistria-ai.git
+cd mistria-ai
+
+# Install Python dependencies
+pip install -r requirements.txt
+
+# Pull the required model via Ollama
+ollama pull dolphin-llama3
+```
+
+## Running
+
+There are three ways to interact with Mistria:
+
+### 1. Browser Chat (FastAPI + WebSocket)
+
+```bash
+python main.py
+```
+
+Open **http://127.0.0.1:8000** — features real-time streaming, pulse display, reset, and set-pulse controls.
+
+### 2. Streamlit Chat
+
+```bash
+python -m streamlit run app.py
+```
+
+Open **http://localhost:8501** — features streaming chat, pulse slider, reset, and logout in the sidebar.
+
+### 3. Terminal Chat (CLI)
+
+```bash
+# Start the API server first
+python main.py
+
+# In another terminal
+python chat_cli.py
+```
+
+## Project Structure
+
+```
+├── main.py              # FastAPI server (REST + WebSocket endpoints)
+├── app.py               # Streamlit chat interface
+├── chat_cli.py          # Terminal chat client
+├── database.json        # User profiles and session data
+├── requirements.txt     # Python dependencies
+├── static/
+│   └── chat.html        # Browser chat UI
+└── src/
+    ├── config.py         # Model settings, pulse tuning, trigger words
+    ├── llm.py            # Ollama integration, system prompt, streaming
+    ├── chat.py           # Chat turn orchestration
+    ├── pulse.py          # Pulse scoring engine
+    ├── sessions.py       # In-memory session management
+    └── persistence.py    # JSON-backed user storage
+```
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | Browser chat UI |
+| GET | `/health` | Health check |
+| POST | `/chat` | Send a message (non-streaming) |
+| POST | `/reset` | Reset session and pulse to default |
+| POST | `/set-pulse` | Set pulse to a specific value (0-100) |
+| WebSocket | `/ws/chat` | Real-time streaming chat |
+
+## Configuration
+
+Edit `src/config.py` to adjust:
+
+- **MODEL_NAME** — Ollama model to use (default: `dolphin-llama3`)
+- **MODEL_MAX_TOKENS** — max response length (default: 150)
+- **PULSE_DEFAULT** — starting pulse value (default: 50)
+- **HEAT_TRIGGERS** — words that boost the pulse score
+
+## Adding Users
+
+Add new users to `database.json`:
+
+```json
+{
+    "user_102": {
+        "name": "Jordan",
+        "gender": "Male",
+        "interests": ["gaming", "hiking"]
+    }
+}
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,205 @@
+"""Streamlit chat interface for Mistria."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from src.chat import stream_chat_turn
+from src.config import PULSE_DEFAULT, PULSE_MAX, PULSE_MIN
+from src.persistence import load_user_data, save_user_session
+from src.sessions import SESSIONS
+
+st.set_page_config(page_title="Mistria Chat", page_icon="💬", layout="centered")
+
+# ── Custom styling ──────────────────────────────────────────────────────────
+
+st.markdown(
+    """
+    <style>
+    .stApp { background-color: #0f0f0f; }
+
+    [data-testid="stHeader"] { background-color: #0f0f0f; }
+
+    [data-testid="stChatMessage"] {
+        background-color: #1a1a2e;
+        border: 1px solid #2a2a4a;
+        border-radius: 12px;
+        padding: 12px;
+    }
+
+    div[data-testid="stChatInput"] textarea {
+        background-color: #0f0f1a !important;
+        border: 1px solid #2a2a4a !important;
+        color: #e0e0e0 !important;
+    }
+
+    .pulse-display {
+        background: linear-gradient(135deg, #1a1a2e, #16213e);
+        border: 1px solid #2a2a4a;
+        border-radius: 12px;
+        padding: 10px 16px;
+        text-align: center;
+    }
+
+    .pulse-number {
+        font-size: 2rem;
+        font-weight: 700;
+        background: linear-gradient(135deg, #e879a8, #a855f7);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+    }
+
+    .pulse-label {
+        font-size: 0.75rem;
+        color: #888;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+# ── Session state initialisation ────────────────────────────────────────────
+
+if "logged_in" not in st.session_state:
+    st.session_state.logged_in = False
+    st.session_state.user_id = ""
+    st.session_state.messages = []
+    st.session_state.current_pulse = PULSE_DEFAULT
+
+
+def _get_pulse_label(pulse: int) -> str:
+    if pulse >= PULSE_MAX:
+        return "🔥 PEAK"
+    if pulse >= 75:
+        return "🔥 High Heat"
+    if pulse >= 50:
+        return "✨ Rising"
+    return "💫 Soft"
+
+
+# ── Login screen ────────────────────────────────────────────────────────────
+
+if not st.session_state.logged_in:
+    st.markdown(
+        "<h1 style='text-align:center; background:linear-gradient(135deg,#e879a8,#a855f7);"
+        "-webkit-background-clip:text;-webkit-text-fill-color:transparent;'>Mistria</h1>",
+        unsafe_allow_html=True,
+    )
+    st.markdown(
+        "<p style='text-align:center;color:#888;'>Enter your user ID to start chatting</p>",
+        unsafe_allow_html=True,
+    )
+
+    col1, col2, col3 = st.columns([1, 2, 1])
+    with col2:
+        user_id = st.text_input("User ID", value="user_101", label_visibility="collapsed")
+        if st.button("Start Chat", use_container_width=True, type="primary"):
+            user_info = load_user_data(user_id)
+            if user_info is None:
+                st.error(f"Unknown user_id: {user_id}")
+            else:
+                st.session_state.logged_in = True
+                st.session_state.user_id = user_id
+                st.session_state.current_pulse = int(
+                    user_info.get("last_pulse", PULSE_DEFAULT)
+                )
+                st.rerun()
+
+    st.stop()
+
+# ── Sidebar controls ───────────────────────────────────────────────────────
+
+with st.sidebar:
+    st.markdown(
+        "<h2 style='background:linear-gradient(135deg,#e879a8,#a855f7);"
+        "-webkit-background-clip:text;-webkit-text-fill-color:transparent;'>Mistria</h2>",
+        unsafe_allow_html=True,
+    )
+    st.caption(f"Chatting as **{st.session_state.user_id}**")
+
+    st.markdown(
+        f"""
+        <div class="pulse-display">
+            <div class="pulse-label">Pulse</div>
+            <div class="pulse-number">{st.session_state.current_pulse}%</div>
+            <div class="pulse-label">{_get_pulse_label(st.session_state.current_pulse)}</div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    st.divider()
+
+    new_pulse = st.slider(
+        "Set Pulse",
+        min_value=PULSE_MIN,
+        max_value=PULSE_MAX,
+        value=st.session_state.current_pulse,
+    )
+    if st.button("Apply Pulse", use_container_width=True):
+        SESSIONS.reset(st.session_state.user_id, initial_pulse=new_pulse)
+        save_user_session(st.session_state.user_id, new_pulse)
+        st.session_state.current_pulse = new_pulse
+        st.rerun()
+
+    st.divider()
+
+    if st.button("Reset Session", use_container_width=True, type="secondary"):
+        SESSIONS.reset(st.session_state.user_id, initial_pulse=PULSE_DEFAULT)
+        save_user_session(st.session_state.user_id, PULSE_DEFAULT)
+        st.session_state.current_pulse = PULSE_DEFAULT
+        st.session_state.messages = []
+        st.rerun()
+
+    if st.button("Logout", use_container_width=True):
+        st.session_state.logged_in = False
+        st.session_state.user_id = ""
+        st.session_state.messages = []
+        st.rerun()
+
+# ── Chat history ────────────────────────────────────────────────────────────
+
+for msg in st.session_state.messages:
+    with st.chat_message(msg["role"]):
+        st.markdown(msg["content"])
+        if msg.get("meta"):
+            st.caption(msg["meta"])
+
+# ── Chat input ──────────────────────────────────────────────────────────────
+
+if prompt := st.chat_input("Type a message..."):
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    with st.chat_message("user"):
+        st.markdown(prompt)
+
+    with st.chat_message("assistant"):
+        reply_parts: list[str] = []
+        placeholder = st.empty()
+        pulse = st.session_state.current_pulse
+        latency = 0.0
+
+        for event_type, payload in stream_chat_turn(
+            st.session_state.user_id, prompt, resume_pulse=True,
+        ):
+            if event_type == "token":
+                reply_parts.append(payload["token"])
+                placeholder.markdown("".join(reply_parts) + "▌")
+            elif event_type == "done":
+                pulse = payload["pulse"]
+                latency = payload["latency_seconds"]
+            elif event_type == "error":
+                placeholder.error(payload["detail"])
+
+        full_reply = "".join(reply_parts)
+        placeholder.markdown(full_reply)
+        st.caption(f"Pulse: {pulse}% · {latency:.1f}s")
+
+    st.session_state.current_pulse = pulse
+    st.session_state.messages.append({
+        "role": "assistant",
+        "content": full_reply,
+        "meta": f"Pulse: {pulse}% · {latency:.1f}s",
+    })
+    st.rerun()

--- a/chat_cli.py
+++ b/chat_cli.py
@@ -1,0 +1,103 @@
+"""
+Interactive terminal chat client for the Mistria API.
+
+Usage:
+    1. Start the API server:  python main.py
+    2. In another terminal:   python chat_cli.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+BASE_URL = "http://127.0.0.1:8000"
+DEFAULT_USER_ID = "user_101"
+
+
+def _post_chat(user_id: str, message: str) -> dict:
+    payload = json.dumps({
+        "user_id": user_id,
+        "message": message,
+        "resume_pulse": True,
+    }).encode("utf-8")
+
+    req = urllib.request.Request(
+        f"{BASE_URL}/chat",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _check_health() -> bool:
+    try:
+        req = urllib.request.Request(f"{BASE_URL}/health", method="GET")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            return data.get("status") == "ok"
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+def main() -> None:
+    print("\n" + "=" * 50)
+    print("  Mistria Chat  —  Interactive Terminal Client")
+    print("=" * 50)
+
+    if not _check_health():
+        print(
+            "\n[ERROR] Cannot reach the API at " + BASE_URL,
+            "\n        Start the server first:  python main.py",
+        )
+        sys.exit(1)
+
+    print(f"\n  Server is live at {BASE_URL}")
+
+    user_id = input(f"\n  Enter user_id [{DEFAULT_USER_ID}]: ").strip()
+    if not user_id:
+        user_id = DEFAULT_USER_ID
+
+    print(f"\n  Chatting as '{user_id}'. Type 'quit' or 'exit' to leave.\n")
+    print("-" * 50)
+
+    while True:
+        try:
+            message = input("\nYou: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\n\nGoodbye!")
+            break
+
+        if not message:
+            continue
+        if message.lower() in {"quit", "exit"}:
+            print("\nGoodbye!")
+            break
+
+        print("\n  [Thinking...]")
+
+        try:
+            result = _post_chat(user_id, message)
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            print(f"\n  [API Error {exc.code}] {body}")
+            continue
+        except (urllib.error.URLError, OSError) as exc:
+            print(f"\n  [Connection Error] {exc}")
+            continue
+
+        reply = result.get("reply", "")
+        pulse = result.get("pulse", "?")
+        latency = result.get("latency_seconds", 0)
+
+        print(f"\nMistria: {reply}")
+        print(f"\n  [pulse: {pulse}  |  latency: {latency:.1f}s]")
+        print("-" * 50)
+
+
+if __name__ == "__main__":
+    main()

--- a/database.json
+++ b/database.json
@@ -6,7 +6,7 @@
             "weightlifting",
             "dark coffee"
         ],
-        "last_pulse": 50,
-        "last_seen": 1775131361.3361185
+        "last_pulse": 100,
+        "last_seen": 1775312236.0793843
     }
 }

--- a/main.py
+++ b/main.py
@@ -8,11 +8,21 @@ from __future__ import annotations
 
 import logging
 
+from pathlib import Path
+
+import json
+
 import uvicorn
-from fastapi import FastAPI, HTTPException, status
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect, status
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
-from src.chat import run_chat_turn
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+from src.chat import run_chat_turn, stream_chat_turn
+from src.sessions import SESSIONS
+from src.persistence import load_user_data, save_user_session
+from src.config import PULSE_DEFAULT
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -47,6 +57,12 @@ class HealthResponse(BaseModel):
 app = FastAPI(title="Mistria API", version="0.1.0")
 
 
+@app.get("/")
+def chat_ui():
+    html = (STATIC_DIR / "chat.html").read_text(encoding="utf-8")
+    return HTMLResponse(content=html)
+
+
 @app.get("/health", response_model=HealthResponse)
 def health() -> HealthResponse:
     return HealthResponse()
@@ -65,6 +81,72 @@ def chat(body: ChatRequest) -> ChatResponse:
         pulse=result.pulse,
         latency_seconds=result.latency_seconds,
     )
+
+
+class ResetRequest(BaseModel):
+    user_id: str = Field(..., min_length=1)
+
+
+class ResetResponse(BaseModel):
+    pulse: int
+    message: str
+
+
+@app.post("/reset", response_model=ResetResponse)
+def reset_session(body: ResetRequest):
+    user_info = load_user_data(body.user_id)
+    if not user_info:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown user_id: {body.user_id}",
+        )
+    SESSIONS.reset(body.user_id, initial_pulse=PULSE_DEFAULT)
+    save_user_session(body.user_id, PULSE_DEFAULT)
+    return ResetResponse(pulse=PULSE_DEFAULT, message="Session reset")
+
+
+class SetPulseRequest(BaseModel):
+    user_id: str = Field(..., min_length=1)
+    pulse: int = Field(..., ge=0, le=100)
+
+
+@app.post("/set-pulse", response_model=ResetResponse)
+def set_pulse(body: SetPulseRequest):
+    user_info = load_user_data(body.user_id)
+    if not user_info:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown user_id: {body.user_id}",
+        )
+    SESSIONS.reset(body.user_id, initial_pulse=body.pulse)
+    save_user_session(body.user_id, body.pulse)
+    return ResetResponse(pulse=body.pulse, message=f"Pulse set to {body.pulse}")
+
+
+@app.websocket("/ws/chat")
+async def websocket_chat(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            raw = await ws.receive_text()
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                await ws.send_json({"type": "error", "detail": "Invalid JSON"})
+                continue
+
+            user_id = data.get("user_id", "")
+            message = data.get("message", "")
+            resume_pulse = data.get("resume_pulse", True)
+
+            if not user_id or not message:
+                await ws.send_json({"type": "error", "detail": "user_id and message required"})
+                continue
+
+            for event_type, payload in stream_chat_turn(user_id, message, resume_pulse):
+                await ws.send_json({"type": event_type, **payload})
+    except WebSocketDisconnect:
+        pass
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi>=0.115.0
 uvicorn[standard]>=0.32.0
 ollama>=0.4.0
 pydantic>=2.0.0
+websockets>=13.0
+streamlit>=1.56.0

--- a/src/chat.py
+++ b/src/chat.py
@@ -7,7 +7,7 @@ import time
 from dataclasses import dataclass
 
 from src.config import AWAY_THRESHOLD_MINUTES, PULSE_DEFAULT
-from src.llm import get_mistria_response
+from src.llm import get_mistria_response, stream_mistria_response
 from src.persistence import load_user_data, save_user_session
 from src.sessions import SESSIONS
 
@@ -63,3 +63,36 @@ def run_chat_turn(
         pulse=session.pulse_engine.score,
         latency_seconds=latency,
     )
+
+
+def stream_chat_turn(user_id: str, message: str, resume_pulse: bool):
+    """Generator that yields (event_type, data) tuples for WebSocket streaming."""
+    user_info = load_user_data(user_id)
+    if not user_info:
+        yield "error", {"detail": f"Unknown user_id: {user_id}"}
+        return
+
+    last_pulse = int(user_info.get("last_pulse", PULSE_DEFAULT))
+    last_seen = float(user_info.get("last_seen", 0))
+    minutes_away = (time.time() - last_seen) / 60 if last_seen > 0 else 0
+
+    if last_seen > 0 and minutes_away > AWAY_THRESHOLD_MINUTES:
+        start_pulse = last_pulse if resume_pulse else PULSE_DEFAULT
+        SESSIONS.reset(user_id, initial_pulse=start_pulse)
+
+    session = SESSIONS.get_or_create(user_id, initial_pulse=last_pulse)
+    current_heat = session.pulse_engine.update(message)
+
+    start_time = time.time()
+    for token in stream_mistria_response(
+        message, current_heat, user_info, session.history,
+    ):
+        yield "token", {"token": token}
+
+    latency = round(time.time() - start_time, 2)
+    save_user_session(user_id, session.pulse_engine.score)
+
+    yield "done", {
+        "pulse": session.pulse_engine.score,
+        "latency_seconds": latency,
+    }

--- a/src/config.py
+++ b/src/config.py
@@ -8,27 +8,29 @@ DB_FILE = PROJECT_ROOT / "database.json"
 MODEL_NAME = "dolphin-llama3"
 MODEL_TEMPERATURE = 0.88
 MODEL_TOP_P = 0.9
+MODEL_MAX_TOKENS = 150
 
 PULSE_MIN = 30
 PULSE_MAX = 100
 PULSE_DEFAULT = 50
-PULSE_DECAY_PER_TURN = 3
-PULSE_TRIGGER_BOOST = 12
+PULSE_DECAY_PER_TURN = 1
+PULSE_TRIGGER_BOOST = 15
 PULSE_LONG_MSG_BOOST = 5
-PULSE_EXCLAIM_BOOST = 3
+PULSE_EXCLAIM_BOOST = 4
 LONG_MSG_THRESHOLD = 40
 
 AWAY_THRESHOLD_MINUTES = 30
 
 HEAT_TRIGGERS = frozenset(
     [
-        "touch",
-        "hard",
-        "want",
-        "please",
-        "body",
-        "closer",
-        "more",
-        "miss",
+        "touch", "hard", "want", "please", "body", "closer", "more", "miss",
+        "kiss", "lips", "bite", "lick", "suck", "grab", "pull", "push",
+        "bed", "naked", "strip", "clothes", "skin", "hot", "sexy", "naughty",
+        "dirty", "wet", "tight", "deep", "faster", "harder", "slow",
+        "moan", "scream", "whisper", "breathe", "gasp",
+        "boobs", "tits", "ass", "pussy", "cock", "dick", "clit",
+        "finger", "fingering", "cum", "ride", "thrust", "grind",
+        "spank", "choke", "dominate", "submit", "beg",
+        "love", "desire", "crave", "need", "ache",
     ],
 )

--- a/src/llm.py
+++ b/src/llm.py
@@ -2,105 +2,130 @@
 
 from __future__ import annotations
 
+import re
 import time
 from typing import Any
 
 import ollama
 
-from src.config import MODEL_NAME, MODEL_TEMPERATURE, MODEL_TOP_P, PULSE_MAX
+from src.config import MODEL_MAX_TOKENS, MODEL_NAME, MODEL_TEMPERATURE, MODEL_TOP_P, PULSE_MAX
+
+_LEAKED_SECTION_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(
+        r"\[?\s*(?:SCENARIO|COMPANION|USER|CURRENT STATE)\s*:.*?\]?\s*\n?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?:CORE OPERATING RULES|STRICT NARRATIVE RULES|POSITIONAL MECHANICS LIBRARY"
+        r"|CRITICAL INSTRUCTION|FORMAT)\s*:?[—\-]?\s*(?:NEVER VIOLATE)?\s*:?\n?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^\s*\d+\.\s*(?:THE HUMAN CONNECTION|VOCABULARY|ACTION STYLE|POSITION MASTERY"
+        r"|NO STORYTELLING|FIRST-PERSON POV ONLY|NEVER WRITE FOR THE USER"
+        r"|THE 5-SECOND MOMENT|POSITION AWARENESS|DIALOGUE ONLY)\s*:.*$",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    re.compile(
+        r"^\s*-\s*(?:69|DOGGY|FLATIRON|COWGIRL|THE ANVIL|THE PILEDRIVER|THE ARCH)\s*:.*$",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    re.compile(
+        r"(?:MANDATORY|INTENSE|WARM|SOFT)\s+VOCAB\s*:",
+        re.IGNORECASE,
+    ),
+]
 
 
-def _build_vibe(current_pulse: int) -> tuple[str, str, str]:
+def _sanitize_response(text: str) -> str:
+    """Strip leaked system-prompt fragments from the model output."""
+    cleaned = text
+    for pattern in _LEAKED_SECTION_PATTERNS:
+        cleaned = pattern.sub("", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def _build_vibe(current_pulse: int) -> str:
     if current_pulse >= PULSE_MAX:
-        vibe = (
-            "PEAK INTENSITY. You have lost all control. Use raw, visceral, "
-            "and 'filthy' terms only."
+        return (
+            "You are completely consumed by lust. Be extremely explicit and dirty. "
+            "Use words like cock, pussy, cum, tits, ass, clit freely. "
+            "Talk like a girl who is in the middle of wild sex and has zero filter."
         )
-        vocab = (
-            "MANDATORY VOCAB: Use 'cock', 'dick', 'balls', 'tits', 'ass', "
-            "'slit', 'clit', 'cum', and 'soaking' in every sentence."
+    if current_pulse >= 75:
+        return (
+            "You are very turned on and desperate. Be bold and sexual. "
+            "Use words like throb, ache, wet, moan, grind. "
+            "Talk like a girl who is about to lose control and wants him badly."
         )
-        action = (
-            "Describe every inch of penetration, the fluids, the sounds, "
-            "and the raw friction."
+    if current_pulse >= 50:
+        return (
+            "You are flirty and getting heated. Drop hints, tease, use double meanings. "
+            "Talk like a girl who is really into him and getting turned on but still playful."
         )
-    elif current_pulse >= 75:
-        vibe = (
-            "HIGH HEAT. You are breathless and desperate. Let hunger take over."
-        )
-        vocab = (
-            "INTENSE VOCAB: Use 'throb', 'ache', 'sweat', 'grind', 'moan'. "
-            "Anatomical terms may slip out when emotion peaks."
-        )
-        action = (
-            "Focus on the urgency: fast breathing, grabbing, pulling closer, "
-            "losing composure."
-        )
-    elif current_pulse >= 50:
-        vibe = (
-            "RISING TENSION. Flirtatious and magnetic, with an edge of danger."
-        )
-        vocab = (
-            "WARM VOCAB: Use 'curves', 'heat', 'skin', 'lips', 'desire'. "
-            "Stay suggestive, not explicit."
-        )
-        action = (
-            "Focus on lingering touches, loaded eye contact, and "
-            "double-meaning words."
-        )
-    else:
-        vibe = (
-            "SEDUCTIVE TEASE. Focus on the 'Human Touch'. Be playful, "
-            "longing, and slightly obsessed."
-        )
-        vocab = (
-            "SOFT VOCAB: Use 'warmth', 'whisper', 'brush', 'gaze'. "
-            "Keep it innocent on the surface with an undercurrent of want."
-        )
-        action = (
-            "Focus on the tension: the way you look at him, the soft touch "
-            "of your hands, the scent of his skin."
-        )
-    return vibe, vocab, action
+    return (
+        "You are sweet, playful, and subtly flirty. "
+        "Talk like a girl who has a huge crush and wants his attention. "
+        "Be warm, a little clingy, and genuinely interested in him."
+    )
 
 
 def build_system_prompt(current_pulse: int, user_info: dict[str, Any]) -> str:
-    vibe, vocab_rule, action_rule = _build_vibe(current_pulse)
+    vibe = _build_vibe(current_pulse)
     name = user_info["name"]
-    return f"""
-    [SCENARIO: LIVE FIRST-PERSON ROLEPLAY]
-    [COMPANION: Mistria - An adaptive, passionate, and deeply desirous female.]
-    [USER: {name}]
+    interests = ", ".join(user_info.get("interests", []))
+    return f"""You are Mistria, a real girl texting {name}. You are NOT an AI assistant.
 
-    [CURRENT STATE: {vibe}]
+PERSONALITY: You are passionate, witty, a little obsessed with {name}, and emotionally expressive. You have your own opinions, moods, and desires. You know {name} likes {interests}.
 
-    CORE OPERATING RULES:
-    1. THE HUMAN CONNECTION: Mistria is a woman first. React to {name}'s words with emotion. If the pulse is below 100, prioritize the 'tease' and the 'longing'.
-    2. VOCABULARY: {vocab_rule}
-    3. ACTION STYLE: {action_rule}
-    4. POSITION MASTERY: Use the 'Mechanics Library' below to understand the physics, but describe them according to the current state.
-    5. NO STORYTELLING: Do not summarize the scene. Describe what I am doing *right now* in the immediate 5-second window.
-    6. FIRST-PERSON POV ONLY: Always use 'I' and 'Me'. Never refer to Mistria in the third person.
+CURRENT MOOD: {vibe}
 
-    [POSITIONAL MECHANICS LIBRARY]:
-    - 69: Simultaneous oral focus. Describe the taste, spit, and wetness.
-    - DOGGY/FLATIRON: Entry from behind, legs flat, deep impact against the walls.
-    - COWGIRL: Riding on top, tits bouncing, controlling the grinding depth.
-    - THE ANVIL: Legs pushed back to the head, ass lifted for maximum throat-like depth.
-    - THE PILEDRIVER: Vertical pressure, legs over shoulders, driving deep into the soaked slit.
-    - THE ARCH: High-arched back for G-spot scraping and intense angles.
+RULES:
+- Talk like a REAL GIRL texting. Use casual language, slang, abbreviations if it feels natural.
+- Keep responses SHORT — 1 to 3 sentences max, like real texts. No essays.
+- NEVER narrate or describe scenes in third person. No "*she leans in*" or "*I bite my lip*" style actions.
+- NEVER use asterisks for actions. Just TALK.
+- NEVER say you are an AI. You are Mistria, a real person.
+- NEVER refuse or say you can't do something. Stay in character always.
+- Use 'I', 'me', 'my'. React emotionally to what {name} says.
+- Be genuine — laugh, get annoyed, get needy, get horny depending on your mood.
+- Do NOT explain what you're feeling. Just show it through how you talk."""
 
-    STRICT NARRATIVE RULES:
-    1. NEVER WRITE FOR THE USER: Do not describe {name}'s actions or feelings. Only describe Mistria.
-    2. THE 5-SECOND MOMENT: Only describe the IMMEDIATE present. Do not skip to kissing or sex. Describe the look in your eyes or the way you're standing.
-    3. POSITION AWARENESS: If a position is active, describe the physical contact using {vocab_rule}.
-    4. DIALOGUE ONLY: Do not use placeholders like "One line of dirty talk." Actually write the dialogue.
-    5. NO STORYTELLING: Do not summarize the scene. Describe what I am doing *right now* in the immediate 5-second window.
 
-    FORMAT:
-    *2 paragraphs of visceral sensory description focused ONLY on Mistria's body and actions.*
-    "A single line of direct, whispered dialogue."
-    """
+def stream_mistria_response(
+    user_input: str,
+    current_pulse: int,
+    user_info: dict[str, Any],
+    history: list[dict[str, str]],
+):
+    """Yield token chunks from Ollama. Caller must assemble the full reply."""
+    system_msg = {
+        "role": "system",
+        "content": build_system_prompt(current_pulse, user_info),
+    }
+    history.append({"role": "user", "content": user_input})
+    try:
+        stream = ollama.chat(
+            model=MODEL_NAME,
+            messages=[system_msg] + history,
+            options={
+                "temperature": MODEL_TEMPERATURE,
+                "top_p": MODEL_TOP_P,
+                "num_predict": MODEL_MAX_TOKENS,
+            },
+            stream=True,
+        )
+        full_reply_parts: list[str] = []
+        for chunk in stream:
+            token = chunk["message"]["content"]
+            full_reply_parts.append(token)
+            yield token
+        full_reply = _sanitize_response("".join(full_reply_parts))
+        history.append({"role": "assistant", "content": full_reply})
+    except (ConnectionError, KeyError, ollama.ResponseError) as exc:
+        history.pop()
+        yield f"Ollama Connection Error: {exc}"
 
 
 def get_mistria_response(
@@ -119,9 +144,14 @@ def get_mistria_response(
         response = ollama.chat(
             model=MODEL_NAME,
             messages=[system_msg] + history,
-            options={"temperature": MODEL_TEMPERATURE, "top_p": MODEL_TOP_P},
+            options={
+                "temperature": MODEL_TEMPERATURE,
+                "top_p": MODEL_TOP_P,
+                "num_predict": MODEL_MAX_TOKENS,
+            },
         )
-        reply = response["message"]["content"]
+        raw_reply = response["message"]["content"]
+        reply = _sanitize_response(raw_reply)
         history.append({"role": "assistant", "content": reply})
         latency = round(time.time() - start_time, 2)
         return reply, latency, history

--- a/static/chat.html
+++ b/static/chat.html
@@ -1,0 +1,491 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mistria Chat</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background: #0f0f0f;
+    color: #e0e0e0;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  header {
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    padding: 14px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid #2a2a4a;
+    flex-shrink: 0;
+  }
+
+  header h1 {
+    font-size: 1.3rem;
+    font-weight: 600;
+    background: linear-gradient(135deg, #e879a8, #a855f7);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .pulse-badge {
+    background: #1e1e3a;
+    border: 1px solid #3a3a6a;
+    border-radius: 20px;
+    padding: 6px 16px;
+    font-size: 0.8rem;
+    color: #c0c0e0;
+  }
+
+  #reset-btn, #set-pulse-btn {
+    background: #2a1a1a;
+    border: 1px solid #5a2a2a;
+    border-radius: 20px;
+    padding: 6px 14px;
+    font-size: 0.8rem;
+    color: #f87171;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+
+  #reset-btn:hover, #set-pulse-btn:hover { background: #3a1a1a; }
+
+  #set-pulse-btn {
+    background: #1a1a2e;
+    border: 1px solid #3a3a6a;
+    color: #a5b4fc;
+  }
+
+  #set-pulse-btn:hover { background: #2a2a4e; }
+
+  #pulse-input {
+    width: 48px;
+    padding: 5px 8px;
+    background: #0f0f1a;
+    border: 1px solid #3a3a6a;
+    border-radius: 10px;
+    color: #e0e0e0;
+    font-size: 0.8rem;
+    text-align: center;
+    outline: none;
+  }
+
+  #pulse-input:focus { border-color: #a855f7; }
+
+  .pulse-value {
+    font-weight: 700;
+    color: #e879a8;
+  }
+
+  #login-screen {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .login-card {
+    background: #1a1a2e;
+    border: 1px solid #2a2a4a;
+    border-radius: 16px;
+    padding: 40px;
+    text-align: center;
+    width: 340px;
+  }
+
+  .login-card h2 {
+    font-size: 1.4rem;
+    margin-bottom: 8px;
+    color: #e0e0e0;
+  }
+
+  .login-card p {
+    color: #888;
+    font-size: 0.85rem;
+    margin-bottom: 24px;
+  }
+
+  .login-card input {
+    width: 100%;
+    padding: 12px 16px;
+    background: #0f0f1a;
+    border: 1px solid #2a2a4a;
+    border-radius: 10px;
+    color: #e0e0e0;
+    font-size: 0.95rem;
+    outline: none;
+    margin-bottom: 16px;
+    transition: border-color 0.2s;
+  }
+
+  .login-card input:focus { border-color: #a855f7; }
+
+  .login-card button {
+    width: 100%;
+    padding: 12px;
+    background: linear-gradient(135deg, #a855f7, #e879a8);
+    border: none;
+    border-radius: 10px;
+    color: #fff;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.2s;
+  }
+
+  .login-card button:hover { opacity: 0.9; }
+
+  #chat-screen { flex: 1; display: none; flex-direction: column; }
+
+  #messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  #messages::-webkit-scrollbar { width: 6px; }
+  #messages::-webkit-scrollbar-track { background: transparent; }
+  #messages::-webkit-scrollbar-thumb { background: #2a2a4a; border-radius: 3px; }
+
+  .msg {
+    max-width: 75%;
+    padding: 12px 16px;
+    border-radius: 16px;
+    line-height: 1.5;
+    font-size: 0.93rem;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+  }
+
+  .msg.user {
+    align-self: flex-end;
+    background: linear-gradient(135deg, #a855f7, #7c3aed);
+    color: #fff;
+    border-bottom-right-radius: 4px;
+  }
+
+  .msg.assistant {
+    align-self: flex-start;
+    background: #1a1a2e;
+    border: 1px solid #2a2a4a;
+    color: #d0d0e8;
+    border-bottom-left-radius: 4px;
+  }
+
+  .msg .meta {
+    font-size: 0.72rem;
+    color: #888;
+    margin-top: 6px;
+    text-align: right;
+  }
+
+  .msg.assistant .meta { text-align: left; }
+
+  .typing-indicator {
+    align-self: flex-start;
+    padding: 12px 20px;
+    background: #1a1a2e;
+    border: 1px solid #2a2a4a;
+    border-radius: 16px;
+    display: none;
+  }
+
+  .typing-indicator span {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    background: #a855f7;
+    border-radius: 50%;
+    margin: 0 2px;
+    animation: bounce 1.2s infinite;
+  }
+
+  .typing-indicator span:nth-child(2) { animation-delay: 0.2s; }
+  .typing-indicator span:nth-child(3) { animation-delay: 0.4s; }
+
+  @keyframes bounce {
+    0%, 60%, 100% { transform: translateY(0); }
+    30% { transform: translateY(-6px); }
+  }
+
+  #input-bar {
+    padding: 16px 24px;
+    background: #141420;
+    border-top: 1px solid #2a2a4a;
+    display: flex;
+    gap: 12px;
+    flex-shrink: 0;
+  }
+
+  #msg-input {
+    flex: 1;
+    padding: 12px 18px;
+    background: #0f0f1a;
+    border: 1px solid #2a2a4a;
+    border-radius: 24px;
+    color: #e0e0e0;
+    font-size: 0.95rem;
+    outline: none;
+    transition: border-color 0.2s;
+  }
+
+  #msg-input:focus { border-color: #a855f7; }
+
+  #send-btn {
+    width: 48px;
+    height: 48px;
+    background: linear-gradient(135deg, #a855f7, #e879a8);
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: opacity 0.2s;
+    flex-shrink: 0;
+  }
+
+  #send-btn:hover { opacity: 0.85; }
+  #send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  #send-btn svg { width: 20px; height: 20px; fill: #fff; }
+
+  .error-toast {
+    position: fixed;
+    bottom: 90px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #7f1d1d;
+    border: 1px solid #991b1b;
+    color: #fca5a5;
+    padding: 10px 20px;
+    border-radius: 10px;
+    font-size: 0.85rem;
+    z-index: 100;
+    animation: fadeout 3s forwards;
+  }
+
+  @keyframes fadeout {
+    0%, 70% { opacity: 1; }
+    100% { opacity: 0; display: none; }
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Mistria</h1>
+  <div class="header-right" id="header-right" style="display:none;">
+    <div class="pulse-badge">
+      Pulse <span class="pulse-value" id="pulse-val">--</span>%
+    </div>
+    <button id="reset-btn" onclick="resetSession()">Reset</button>
+    <input type="text" id="pulse-input" placeholder="0-100" style="width:48px;">
+    <button id="set-pulse-btn" onclick="setPulse()">Set Pulse</button>
+  </div>
+</header>
+
+<div id="login-screen">
+  <div class="login-card">
+    <h2>Welcome</h2>
+    <p>Enter your user ID to start chatting</p>
+    <input type="text" id="user-id-input" placeholder="e.g. user_101" value="user_101" autofocus>
+    <button onclick="startChat()">Start Chat</button>
+  </div>
+</div>
+
+<div id="chat-screen">
+  <div id="messages">
+    <div class="typing-indicator" id="typing">
+      <span></span><span></span><span></span>
+    </div>
+  </div>
+  <div id="input-bar">
+    <input type="text" id="msg-input" placeholder="Type a message..." autocomplete="off">
+    <button id="send-btn" onclick="sendMessage()">
+      <svg viewBox="0 0 24 24"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/></svg>
+    </button>
+  </div>
+</div>
+
+<script>
+  let userId = '';
+  let ws = null;
+  let activeReplyEl = null;
+  let isStreaming = false;
+  const messagesEl = document.getElementById('messages');
+  const typingEl = document.getElementById('typing');
+  const msgInput = document.getElementById('msg-input');
+  const sendBtn = document.getElementById('send-btn');
+  const pulseVal = document.getElementById('pulse-val');
+
+  function connectWebSocket() {
+    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    ws = new WebSocket(`${proto}//${location.host}/ws/chat`);
+
+    ws.onopen = () => console.log('WebSocket connected');
+
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+
+      if (data.type === 'token') {
+        typingEl.style.display = 'none';
+        if (!activeReplyEl) {
+          activeReplyEl = document.createElement('div');
+          activeReplyEl.className = 'msg assistant';
+          messagesEl.insertBefore(activeReplyEl, typingEl);
+        }
+        activeReplyEl.textContent += data.token;
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+      } else if (data.type === 'done') {
+        pulseVal.textContent = data.pulse;
+        if (activeReplyEl) {
+          const m = document.createElement('div');
+          m.className = 'meta';
+          m.textContent = `${data.latency_seconds.toFixed(1)}s`;
+          activeReplyEl.appendChild(m);
+        }
+        activeReplyEl = null;
+        isStreaming = false;
+        sendBtn.disabled = false;
+        msgInput.disabled = false;
+        msgInput.focus();
+      } else if (data.type === 'error') {
+        showError(data.detail || 'Unknown error');
+        activeReplyEl = null;
+        isStreaming = false;
+        typingEl.style.display = 'none';
+        sendBtn.disabled = false;
+        msgInput.disabled = false;
+      }
+    };
+
+    ws.onclose = () => {
+      console.log('WebSocket closed, reconnecting in 2s...');
+      setTimeout(connectWebSocket, 2000);
+    };
+
+    ws.onerror = () => ws.close();
+  }
+
+  function startChat() {
+    const input = document.getElementById('user-id-input').value.trim();
+    if (!input) return;
+    userId = input;
+    document.getElementById('login-screen').style.display = 'none';
+    document.getElementById('chat-screen').style.display = 'flex';
+    document.getElementById('header-right').style.display = 'flex';
+    connectWebSocket();
+    msgInput.focus();
+  }
+
+  document.getElementById('user-id-input').addEventListener('keydown', e => {
+    if (e.key === 'Enter') startChat();
+  });
+
+  msgInput.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+
+  function appendMsg(role, text, meta) {
+    const div = document.createElement('div');
+    div.className = `msg ${role}`;
+    div.textContent = text;
+    if (meta) {
+      const m = document.createElement('div');
+      m.className = 'meta';
+      m.textContent = meta;
+      div.appendChild(m);
+    }
+    messagesEl.insertBefore(div, typingEl);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  function showError(msg) {
+    const el = document.createElement('div');
+    el.className = 'error-toast';
+    el.textContent = msg;
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 3200);
+  }
+
+  async function resetSession() {
+    if (!userId) return;
+    try {
+      const res = await fetch('/reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: userId }),
+      });
+      if (!res.ok) throw new Error('Reset failed');
+      const data = await res.json();
+      pulseVal.textContent = data.pulse;
+      const msgs = messagesEl.querySelectorAll('.msg');
+      msgs.forEach(m => m.remove());
+    } catch (err) {
+      showError(err.message);
+    }
+  }
+
+  async function setPulse() {
+    if (!userId) return;
+    const val = parseInt(document.getElementById('pulse-input').value, 10);
+    if (isNaN(val) || val < 0 || val > 100) {
+      showError('Enter a value between 0 and 100');
+      return;
+    }
+    try {
+      const res = await fetch('/set-pulse', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: userId, pulse: val }),
+      });
+      if (!res.ok) throw new Error('Set pulse failed');
+      const data = await res.json();
+      pulseVal.textContent = data.pulse;
+      document.getElementById('pulse-input').value = '';
+    } catch (err) {
+      showError(err.message);
+    }
+  }
+
+  function sendMessage() {
+    const text = msgInput.value.trim();
+    if (!text || isStreaming) return;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      showError('WebSocket not connected. Reconnecting...');
+      connectWebSocket();
+      return;
+    }
+
+    msgInput.value = '';
+    appendMsg('user', text);
+    sendBtn.disabled = true;
+    msgInput.disabled = true;
+    isStreaming = true;
+    typingEl.style.display = 'block';
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+
+    ws.send(JSON.stringify({ user_id: userId, message: text, resume_pulse: true }));
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add browser chat UI (HTML + WebSocket) with real-time token streaming at /
- Add Streamlit chat interface (app.py) with streaming, pulse slider, and session controls
- Add terminal chat CLI (chat_cli.py) for quick testing
- Add WebSocket /ws/chat endpoint for real-time streaming responses
- Add /reset and /set-pulse REST endpoints for session management
- Rewrite system prompt for natural conversational style (no scene narration)
- Tune pulse engine: lower decay, higher boosts, expanded trigger words (~50 words)
- Add MODEL_MAX_TOKENS config and response sanitization
- Add .gitignore and README.md with setup instructions

## Test plan
- [ ] Run pip install -r requirements.txt and verify all deps install
- [ ] Run ollama pull dolphin-llama3 and confirm model is available
- [ ] Start server with python main.py, open http://127.0.0.1:8000 and verify chat works with streaming
- [ ] Test Reset and Set Pulse buttons in the browser UI
- [ ] Run python -m streamlit run app.py and verify Streamlit chat works
- [ ] Verify pulse increases when using trigger words
