### PR TITLE
feat: Add memory configuration and package structure

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -160,6 +160,19 @@ class AppLogging:
 
 
 @dataclass(frozen=True, slots=True)
+class Memory:
+    """Long-term memory layer settings."""
+    enabled: bool = _get_bool("MISTRIA_MEMORY_ENABLED", False)
+    qdrant_url: str = _get_str("MISTRIA_MEMORY_QDRANT_URL", "http://localhost:6333")
+    qdrant_collection: str = _get_str("MISTRIA_MEMORY_QDRANT_COLLECTION", "mistria_memories")
+    embedding_model_name: str = _get_str("MISTRIA_MEMORY_EMBEDDING_MODEL_NAME", "all-MiniLM-L6-v2")
+    retrieval_top_k: int = _get_int("MISTRIA_MEMORY_RETRIEVAL_TOP_K", 5)
+    retrieval_min_score: float = _get_float("MISTRIA_MEMORY_RETRIEVAL_MIN_SCORE", 0.35)
+    raw_content_logging_enabled: bool = _get_bool("MISTRIA_MEMORY_RAW_CONTENT_LOGGING_ENABLED", True)
+    extraction_enabled: bool = _get_bool("MISTRIA_MEMORY_EXTRACTION_ENABLED", False)
+
+
+@dataclass(frozen=True, slots=True)
 class Secrets:
     """Secret configuration loaded from the environment."""
     api_key: str = field(default_factory=lambda: _get_str("MISTRIA_API_KEY", "local-dev-api-key"))
@@ -177,6 +190,7 @@ class Settings:
     chat: Chat = field(default_factory=Chat)
     inference: Inference = field(default_factory=Inference)
     logging: AppLogging = field(default_factory=AppLogging)
+    memory: Memory = field(default_factory=Memory)
     storage: Storage = field(default_factory=Storage)
     secrets: Secrets = field(default_factory=Secrets)
 

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,0 +1,11 @@
+"""Expose the memory module public API."""
+
+from src.memory.contracts import MemoryScope
+from src.memory.schemas import MemoryEntry
+from src.memory.service import MemoryService
+
+__all__ = [
+    "MemoryEntry",
+    "MemoryScope",
+    "MemoryService",
+]

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,11 +1,7 @@
 """Expose the memory module public API."""
 
-from src.memory.contracts import MemoryScope
-from src.memory.schemas import MemoryEntry
 from src.memory.service import MemoryService
 
 __all__ = [
-    "MemoryEntry",
-    "MemoryScope",
     "MemoryService",
 ]

--- a/src/memory/contracts.py
+++ b/src/memory/contracts.py
@@ -1,19 +1,4 @@
-"""Domain contracts for the memory subsystem."""
+"""Domain contracts for the memory subsystem.
 
-from __future__ import annotations
-
-from dataclasses import dataclass
-from typing import Literal
-
-MemoryCategory = Literal["fact", "preference", "event", "relationship"]
-
-
-@dataclass(frozen=True, slots=True)
-class MemoryScope:
-    """Isolation key for all memory operations.
-
-    Every memory operation must be scoped to a specific user and companion
-    pair, ensuring that memories are never shared across companions.
-    """
-    user_id: int
-    ai_companion_id: int
+Types and constants will be added as extraction and retrieval are implemented.
+"""

--- a/src/memory/contracts.py
+++ b/src/memory/contracts.py
@@ -1,0 +1,19 @@
+"""Domain contracts for the memory subsystem."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+MemoryCategory = Literal["fact", "preference", "event", "relationship"]
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryScope:
+    """Isolation key for all memory operations.
+
+    Every memory operation must be scoped to a specific user and companion
+    pair, ensuring that memories are never shared across companions.
+    """
+    user_id: int
+    ai_companion_id: int

--- a/src/memory/prompts.py
+++ b/src/memory/prompts.py
@@ -1,14 +1,4 @@
-"""Prompt templates for the memory extraction pipeline."""
+"""Prompt templates for the memory subsystem.
 
-MEMORY_EXTRACTION_SYSTEM_PROMPT = (
-    "You are a memory extraction engine. Given a conversation turn, "
-    "identify and extract distinct facts, preferences, events, or relationship details "
-    "that the user has shared. Return them as structured JSON."
-)
-
-MEMORY_EXTRACTION_USER_PROMPT = """Extract memorable facts from this conversation turn:
-
-{conversation_text}
-
-Return a JSON array of objects, each with "content", "category", and "confidence" fields.
-Categories: "fact", "preference", "event", "relationship"."""
+Extraction and retrieval prompts will be added in subsequent issues.
+"""

--- a/src/memory/prompts.py
+++ b/src/memory/prompts.py
@@ -1,0 +1,14 @@
+"""Prompt templates for the memory extraction pipeline."""
+
+MEMORY_EXTRACTION_SYSTEM_PROMPT = (
+    "You are a memory extraction engine. Given a conversation turn, "
+    "identify and extract distinct facts, preferences, events, or relationship details "
+    "that the user has shared. Return them as structured JSON."
+)
+
+MEMORY_EXTRACTION_USER_PROMPT = """Extract memorable facts from this conversation turn:
+
+{conversation_text}
+
+Return a JSON array of objects, each with "content", "category", and "confidence" fields.
+Categories: "fact", "preference", "event", "relationship"."""

--- a/src/memory/schemas.py
+++ b/src/memory/schemas.py
@@ -1,0 +1,17 @@
+"""Pydantic schemas for the memory subsystem."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.memory.contracts import MemoryCategory
+
+
+class MemoryEntry(BaseModel):
+    """A single extracted memory fact."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    content: str = Field(min_length=1, description="The extracted memory text")
+    category: MemoryCategory = Field(description="Classification of the memory")
+    confidence: float = Field(ge=0.0, le=1.0, default=1.0, description="Extraction confidence score")

--- a/src/memory/schemas.py
+++ b/src/memory/schemas.py
@@ -1,17 +1,4 @@
-"""Pydantic schemas for the memory subsystem."""
+"""Pydantic schemas for the memory subsystem.
 
-from __future__ import annotations
-
-from pydantic import BaseModel, ConfigDict, Field
-
-from src.memory.contracts import MemoryCategory
-
-
-class MemoryEntry(BaseModel):
-    """A single extracted memory fact."""
-
-    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
-
-    content: str = Field(min_length=1, description="The extracted memory text")
-    category: MemoryCategory = Field(description="Classification of the memory")
-    confidence: float = Field(ge=0.0, le=1.0, default=1.0, description="Extraction confidence score")
+Data transfer models will be added as extraction and retrieval are implemented.
+"""

--- a/src/memory/service.py
+++ b/src/memory/service.py
@@ -1,0 +1,41 @@
+"""Memory service coordinating extraction and retrieval."""
+
+from __future__ import annotations
+
+from src.Logging import get_logger
+from src.config import Memory
+from src.memory.contracts import MemoryScope
+from src.memory.schemas import MemoryEntry
+
+logger = get_logger(__name__)
+
+
+class MemoryService:
+    """Coordinate memory extraction, storage, and retrieval.
+
+    This service is the single entry point for the memory subsystem.
+    Actual extraction and vector retrieval logic will be implemented
+    in subsequent issues.
+    """
+
+    def __init__(self, config: Memory):
+        self.config = config
+        logger.info(
+            "Memory service initialized enabled=%s extraction=%s",
+            config.enabled,
+            config.extraction_enabled,
+        )
+
+    def extract(self, scope: MemoryScope, conversation_text: str) -> list[MemoryEntry]:
+        """Extract memory entries from a conversation turn.
+
+        Not yet implemented. Will be added in a future issue.
+        """
+        raise NotImplementedError("Memory extraction will be implemented in a future issue.")
+
+    def retrieve(self, scope: MemoryScope, query: str, top_k: int | None = None) -> list[MemoryEntry]:
+        """Retrieve relevant memories for a query.
+
+        Not yet implemented. Will be added in a future issue.
+        """
+        raise NotImplementedError("Memory retrieval will be implemented in a future issue.")

--- a/src/memory/service.py
+++ b/src/memory/service.py
@@ -1,41 +1,22 @@
-"""Memory service coordinating extraction and retrieval."""
+"""Memory service entry point."""
 
 from __future__ import annotations
 
 from src.Logging import get_logger
 from src.config import Memory
-from src.memory.contracts import MemoryScope
-from src.memory.schemas import MemoryEntry
 
 logger = get_logger(__name__)
 
 
 class MemoryService:
-    """Coordinate memory extraction, storage, and retrieval.
+    """Entry point for the memory subsystem.
 
-    This service is the single entry point for the memory subsystem.
-    Actual extraction and vector retrieval logic will be implemented
-    in subsequent issues.
+    Extraction and retrieval methods will be added in subsequent issues.
     """
 
     def __init__(self, config: Memory):
         self.config = config
         logger.info(
-            "Memory service initialized enabled=%s extraction=%s",
+            "Memory service initialized enabled=%s",
             config.enabled,
-            config.extraction_enabled,
         )
-
-    def extract(self, scope: MemoryScope, conversation_text: str) -> list[MemoryEntry]:
-        """Extract memory entries from a conversation turn.
-
-        Not yet implemented. Will be added in a future issue.
-        """
-        raise NotImplementedError("Memory extraction will be implemented in a future issue.")
-
-    def retrieve(self, scope: MemoryScope, query: str, top_k: int | None = None) -> list[MemoryEntry]:
-        """Retrieve relevant memories for a query.
-
-        Not yet implemented. Will be added in a future issue.
-        """
-        raise NotImplementedError("Memory retrieval will be implemented in a future issue.")

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -31,29 +31,5 @@ def test_memory_config_in_settings():
 
 def test_memory_package_imports_cleanly():
     """The memory package can be imported without errors."""
-    from src.memory import MemoryEntry, MemoryScope, MemoryService
-    assert MemoryEntry is not None
-    assert MemoryScope is not None
+    from src.memory import MemoryService
     assert MemoryService is not None
-
-
-def test_memory_scope_is_frozen():
-    """MemoryScope is immutable after creation."""
-    from src.memory.contracts import MemoryScope
-    scope = MemoryScope(user_id=1, ai_companion_id=2)
-    assert scope.user_id == 1
-    assert scope.ai_companion_id == 2
-    with pytest.raises(AttributeError):
-        scope.user_id = 99
-
-
-def test_memory_entry_validation():
-    """MemoryEntry enforces field constraints."""
-    from src.memory.schemas import MemoryEntry
-    entry = MemoryEntry(content="User likes coffee", category="preference", confidence=0.9)
-    assert entry.content == "User likes coffee"
-    assert entry.category == "preference"
-    assert entry.confidence == 0.9
-
-    with pytest.raises(Exception):
-        MemoryEntry(content="", category="preference")

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -1,0 +1,59 @@
+"""Tests for memory configuration defaults and environment variable parsing."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_memory_config_defaults():
+    """Memory config has safe defaults for local development."""
+    from src.config import Memory
+    config = Memory()
+    assert config.enabled is False
+    assert config.extraction_enabled is False
+    assert config.qdrant_url == "http://localhost:6333"
+    assert config.qdrant_collection == "mistria_memories"
+    assert config.embedding_model_name == "all-MiniLM-L6-v2"
+    assert config.retrieval_top_k == 5
+    assert config.retrieval_min_score == 0.35
+    assert config.raw_content_logging_enabled is True
+
+
+def test_memory_config_in_settings():
+    """settings.memory exists and is a Memory instance."""
+    from src.config import settings, Memory
+    assert hasattr(settings, "memory")
+    assert isinstance(settings.memory, Memory)
+
+
+def test_memory_package_imports_cleanly():
+    """The memory package can be imported without errors."""
+    from src.memory import MemoryEntry, MemoryScope, MemoryService
+    assert MemoryEntry is not None
+    assert MemoryScope is not None
+    assert MemoryService is not None
+
+
+def test_memory_scope_is_frozen():
+    """MemoryScope is immutable after creation."""
+    from src.memory.contracts import MemoryScope
+    scope = MemoryScope(user_id=1, ai_companion_id=2)
+    assert scope.user_id == 1
+    assert scope.ai_companion_id == 2
+    with pytest.raises(AttributeError):
+        scope.user_id = 99
+
+
+def test_memory_entry_validation():
+    """MemoryEntry enforces field constraints."""
+    from src.memory.schemas import MemoryEntry
+    entry = MemoryEntry(content="User likes coffee", category="preference", confidence=0.9)
+    assert entry.content == "User likes coffee"
+    assert entry.category == "preference"
+    assert entry.confidence == 0.9
+
+    with pytest.raises(Exception):
+        MemoryEntry(content="", category="preference")


### PR DESCRIPTION
Fixes #30

### Changes:
- Added \Memory\ configuration dataclass to \src/config.py\ with required fields and defaults.
- Created \src/memory\ package structure with \__init__.py\, \contracts.py\, \schemas.py\, \service.py\, and \prompts.py\.
- Added unit tests in \	ests/test_memory_config.py\ to verify configuration and clean imports.

**Note:** As per the scope, this PR contains structure and configuration only. Memory extraction and retrieval implementations are omitted.