### PR TITLE
feat: Add SQLite schema and dataclasses for long-term memories

### DIFF
--- a/src/storage/database.py
+++ b/src/storage/database.py
@@ -275,6 +275,32 @@ class SQLiteDatabase:
             ) ON DELETE CASCADE
                 )
             """,
+            """
+            CREATE TABLE IF NOT EXISTS memories
+            (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                ai_companion_id INTEGER NOT NULL,
+                source_conversation_id INTEGER,
+                source_message_id INTEGER,
+                memory_type TEXT NOT NULL CHECK (memory_type IN ('fact','preference','pattern','emotional')),
+                canonical_key TEXT NOT NULL,
+                content TEXT NOT NULL,
+                importance INTEGER NOT NULL,
+                confidence REAL NOT NULL,
+                status TEXT NOT NULL CHECK (status IN ('active','superseded','archived')) DEFAULT 'active',
+                supersedes_memory_id INTEGER,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                last_retrieved_at TEXT,
+                retrieval_count INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+                FOREIGN KEY (ai_companion_id) REFERENCES ai_companion (id) ON DELETE CASCADE,
+                FOREIGN KEY (source_conversation_id) REFERENCES conversations (id) ON DELETE SET NULL,
+                FOREIGN KEY (source_message_id) REFERENCES messages (id) ON DELETE SET NULL,
+                FOREIGN KEY (supersedes_memory_id) REFERENCES memories (id) ON DELETE SET NULL
+            )
+            """,
         )
 
         index_statements = (
@@ -300,6 +326,18 @@ class SQLiteDatabase:
             """
             CREATE INDEX IF NOT EXISTS idx_messages_conversation_created_at
                 ON messages(conversation_id, created_at ASC, id ASC)
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_memories_scope_status
+                ON memories(user_id, ai_companion_id, status)
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_memories_scope_key_status
+                ON memories(user_id, ai_companion_id, canonical_key, status)
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_memories_source_message
+                ON memories(source_message_id)
             """,
         )
 
@@ -371,6 +409,18 @@ class SQLiteDatabase:
             UPDATE conversations
             SET updated_at = CURRENT_TIMESTAMP
             WHERE id = NEW.conversation_id;
+            END
+            """,
+            """
+            CREATE TRIGGER IF NOT EXISTS trg_memories_updated_at
+            AFTER
+            UPDATE ON memories
+                FOR EACH ROW
+                WHEN NEW.updated_at = OLD.updated_at
+            BEGIN
+            UPDATE memories
+            SET updated_at = CURRENT_TIMESTAMP
+            WHERE id = OLD.id;
             END
             """,
         )

--- a/src/storage/models.py
+++ b/src/storage/models.py
@@ -70,3 +70,24 @@ class MessageRecord:
     content: str
     created_at: str
     updated_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRecord:
+    """Persisted long-term memory row."""
+    id: int
+    user_id: int
+    ai_companion_id: int
+    source_conversation_id: int | None
+    source_message_id: int | None
+    memory_type: str
+    canonical_key: str
+    content: str
+    importance: int
+    confidence: float
+    status: str
+    supersedes_memory_id: int | None
+    created_at: str
+    updated_at: str
+    last_retrieved_at: str | None
+    retrieval_count: int

--- a/tests/test_database_schema.py
+++ b/tests/test_database_schema.py
@@ -1,0 +1,87 @@
+"""Tests for the database schema."""
+
+from pathlib import Path
+import sys
+import tempfile
+import sqlite3
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.storage.database import SQLiteDatabase
+
+
+def test_database_initializes_and_creates_memories_table():
+    """Verify that a fresh database creates the memories table with the expected schema."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        db = SQLiteDatabase(str(db_path))
+        db.initialize()
+
+        with db.connection() as conn:
+            # Verify the memories table exists
+            cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='memories'")
+            table = cursor.fetchone()
+            assert table is not None
+
+            # Verify the schema has the correct columns
+            cursor = conn.execute("PRAGMA table_info(memories)")
+            columns = {row["name"]: row["type"] for row in cursor.fetchall()}
+            
+            assert columns["id"] == "INTEGER"
+            assert columns["user_id"] == "INTEGER"
+            assert columns["ai_companion_id"] == "INTEGER"
+            assert columns["memory_type"] == "TEXT"
+            assert columns["canonical_key"] == "TEXT"
+            assert columns["content"] == "TEXT"
+            assert columns["importance"] == "INTEGER"
+            assert columns["confidence"] == "REAL"
+            assert columns["status"] == "TEXT"
+
+
+def test_database_memories_constraints():
+    """Verify that the memories table enforces CHECK constraints."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "test.db"
+        db = SQLiteDatabase(str(db_path))
+        db.initialize()
+
+        with db.connection() as conn:
+            # Create a user and a companion first
+            conn.execute("INSERT INTO users (email, name) VALUES ('test@example.com', 'Test User')")
+            user_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+            conn.execute(
+                """
+                INSERT INTO ai_companion (user_id, title, description, gender, style, ethnicity, eye_color, hair_style, hair_color, personality, voice, connection)
+                VALUES (?, 'Aria', 'Desc', 'Female', 'Anime', 'East Asian', 'Brown', 'Long', 'Black', 'Sweet', 'Soft', 'Friend')
+                """, (user_id,)
+            )
+            companion_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+            # Valid insert
+            conn.execute(
+                """
+                INSERT INTO memories (user_id, ai_companion_id, memory_type, canonical_key, content, importance, confidence)
+                VALUES (?, ?, 'fact', 'user_likes_coffee', 'User likes coffee', 1, 1.0)
+                """, (user_id, companion_id)
+            )
+
+            # Invalid memory_type
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    INSERT INTO memories (user_id, ai_companion_id, memory_type, canonical_key, content, importance, confidence)
+                    VALUES (?, ?, 'invalid_type', 'key', 'content', 1, 1.0)
+                    """, (user_id, companion_id)
+                )
+
+            # Invalid status
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    INSERT INTO memories (user_id, ai_companion_id, memory_type, canonical_key, content, importance, confidence, status)
+                    VALUES (?, ?, 'fact', 'key', 'content', 1, 1.0, 'invalid_status')
+                    """, (user_id, companion_id)
+                )


### PR DESCRIPTION
Fixes #31

### Changes:
- Added \memories\ table schema to \src/storage/database.py\ with appropriate constraints, foreign keys, triggers, and indices.
- Added \MemoryRecord\ dataclass to \src/storage/models.py\ matching the existing \rozen=True, slots=True\ style.
- Added unit tests in \	ests/test_database_schema.py\ to verify schema creation and constraints.

**Note:** As per the scope, this PR contains schema and configuration only. Memory extraction and retrieval logic are omitted.