### PR TITLE
feat: Add internal debug endpoint for memory retrieval

### DIFF
--- a/main.py
+++ b/main.py
@@ -303,8 +303,7 @@ async def debug_memory_retrieve(payload: DebugMemoryRetrieveRequest) -> DebugMem
     memories = await memory_service.retrieve_memories(
         user_id=user.id,
         ai_companion_id=companion.id,
-        query_text=payload.user_message,
-        limit=settings.memory.retrieval_top_k,
+        query=payload.user_message,
     )
 
     return DebugMemoryRetrieveResponse(

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@
 from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI, Query, WebSocket, status
+from fastapi import FastAPI, Query, WebSocket, status, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
@@ -30,6 +30,7 @@ from src.config import settings
 from src.memory.background import MemoryExtractionWorker
 from src.memory.embeddings import LocalEmbeddingProvider
 from src.memory.extraction import MemoryExtractionService
+from src.memory.schemas import DebugMemoryRetrieveRequest, DebugMemoryRetrieveResponse
 from src.memory.service import MemoryService
 from src.memory.vector_store import QdrantVectorStore
 from src.storage.database import SQLiteDatabase
@@ -280,6 +281,37 @@ def get_ai_companion(ai_companion_id: int) -> AICompanionResponse:
     """Fetch one AI companion persona by its internal identifier."""
     logger.debug("Fetching AI companion via API ai_companion_id=%s", ai_companion_id)
     return companion_service.get_ai_companion(ai_companion_id)
+
+
+@app.post("/debug/memory/retrieve", response_model=DebugMemoryRetrieveResponse)
+async def debug_memory_retrieve(payload: DebugMemoryRetrieveRequest) -> DebugMemoryRetrieveResponse:
+    """Internal debug endpoint for memory retrieval."""
+    if not settings.memory.debug_endpoint_enabled or not memory_service:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Endpoint disabled or memory system not configured"
+        )
+
+    user = user_repository.find_by_email(payload.user_mail_id)
+    if not user:
+        raise CompanionNotFoundError("User not found.")
+
+    companion = ai_companion_repository.get_latest_ai_companion(user.id, payload.ai_companion_id)
+    if not companion:
+        raise CompanionNotFoundError(f"Companion {payload.ai_companion_id} not found or not owned by user.")
+
+    memories = await memory_service.retrieve_memories(
+        user_id=user.id,
+        ai_companion_id=companion.id,
+        query_text=payload.user_message,
+        limit=settings.memory.retrieval_top_k,
+    )
+
+    return DebugMemoryRetrieveResponse(
+        user_mail_id=payload.user_mail_id,
+        ai_companion_id=payload.ai_companion_id,
+        memories=memories,
+    )
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -296,8 +296,8 @@ async def debug_memory_retrieve(payload: DebugMemoryRetrieveRequest) -> DebugMem
     if not user:
         raise CompanionNotFoundError("User not found.")
 
-    companion = ai_companion_repository.get_latest_ai_companion(user.id, payload.ai_companion_id)
-    if not companion:
+    companion = ai_companion_repository.find_by_id(payload.ai_companion_id)
+    if not companion or companion.user_id != user.id:
         raise CompanionNotFoundError(f"Companion {payload.ai_companion_id} not found or not owned by user.")
 
     memories = await memory_service.retrieve_memories(

--- a/src/config.py
+++ b/src/config.py
@@ -170,6 +170,7 @@ class Memory:
     retrieval_min_score: float = _get_float("MISTRIA_MEMORY_RETRIEVAL_MIN_SCORE", 0.35)
     raw_content_logging_enabled: bool = _get_bool("MISTRIA_MEMORY_RAW_CONTENT_LOGGING_ENABLED", True)
     extraction_enabled: bool = _get_bool("MISTRIA_MEMORY_EXTRACTION_ENABLED", False)
+    debug_endpoint_enabled: bool = _get_bool("MISTRIA_MEMORY_DEBUG_ENDPOINT_ENABLED", False)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/memory/schemas.py
+++ b/src/memory/schemas.py
@@ -62,3 +62,23 @@ class MemorySearchResult(BaseModel):
     )
 
 
+class DebugMemoryRetrieveRequest(BaseModel):
+    """Request schema for internal memory retrieval debugging."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_mail_id: str = Field(description="The email address of the user.")
+    ai_companion_id: int = Field(description="The ID of the AI companion.")
+    user_message: str = Field(description="The hypothetical query or user message.")
+
+
+class DebugMemoryRetrieveResponse(BaseModel):
+    """Response schema for internal memory retrieval debugging."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_mail_id: str = Field(description="The email address of the user.")
+    ai_companion_id: int = Field(description="The ID of the AI companion.")
+    memories: list[MemorySearchResult] = Field(description="The memory results that would be retrieved.")
+
+

--- a/tests/unit/backend/test_main_endpoints.py
+++ b/tests/unit/backend/test_main_endpoints.py
@@ -315,5 +315,5 @@ async def test_debug_memory_retrieve_success(monkeypatch, sample_user):
     assert len(response.memories) == 1
     assert response.memories[0].memory_id == 1
     memory_service.retrieve_memories.assert_awaited_once_with(
-        user_id=sample_user.id, ai_companion_id=mock_companion.id, query_text="hello", limit=5
+        user_id=sample_user.id, ai_companion_id=mock_companion.id, query="hello"
     )

--- a/tests/unit/backend/test_main_endpoints.py
+++ b/tests/unit/backend/test_main_endpoints.py
@@ -272,7 +272,7 @@ async def test_debug_memory_retrieve_returns_404_when_companion_not_found(monkey
     monkeypatch.setattr(main, "user_repository", user_repo)
 
     companion_repo = mock.Mock()
-    companion_repo.get_latest_ai_companion.return_value = None
+    companion_repo.find_by_id.return_value = None
     monkeypatch.setattr(main, "ai_companion_repository", companion_repo)
 
     from src.memory.schemas import DebugMemoryRetrieveRequest
@@ -294,8 +294,8 @@ async def test_debug_memory_retrieve_success(monkeypatch, sample_user):
     monkeypatch.setattr(main, "user_repository", user_repo)
 
     companion_repo = mock.Mock()
-    mock_companion = mock.Mock(id=99)
-    companion_repo.get_latest_ai_companion.return_value = mock_companion
+    mock_companion = mock.Mock(id=99, user_id=sample_user.id)
+    companion_repo.find_by_id.return_value = mock_companion
     monkeypatch.setattr(main, "ai_companion_repository", companion_repo)
 
     memory_service = mock.Mock()

--- a/tests/unit/backend/test_main_endpoints.py
+++ b/tests/unit/backend/test_main_endpoints.py
@@ -225,12 +225,16 @@ async def test_companion_endpoints_delegate_to_service(monkeypatch):
     assert main.get_ai_companion(3) == "ai-companion"
 
 
+from src.storage.repositories import SQLiteUserRepository, SQLiteAICompanionRepository
+from src.memory.service import MemoryService
+
+
 @pytest.mark.anyio
 async def test_debug_memory_retrieve_returns_404_when_disabled(monkeypatch):
     mock_settings = mock.Mock()
     mock_settings.memory.debug_endpoint_enabled = False
     monkeypatch.setattr(main, "settings", mock_settings)
-    monkeypatch.setattr(main, "memory_service", mock.Mock())
+    monkeypatch.setattr(main, "memory_service", mock.create_autospec(MemoryService, instance=True))
 
     from src.memory.schemas import DebugMemoryRetrieveRequest
     payload = DebugMemoryRetrieveRequest(user_mail_id="user@example.com", ai_companion_id=1, user_message="hello")
@@ -247,9 +251,9 @@ async def test_debug_memory_retrieve_returns_404_when_user_not_found(monkeypatch
     mock_settings = mock.Mock()
     mock_settings.memory.debug_endpoint_enabled = True
     monkeypatch.setattr(main, "settings", mock_settings)
-    monkeypatch.setattr(main, "memory_service", mock.Mock())
+    monkeypatch.setattr(main, "memory_service", mock.create_autospec(MemoryService, instance=True))
 
-    user_repo = mock.Mock()
+    user_repo = mock.create_autospec(SQLiteUserRepository, instance=True)
     user_repo.find_by_email.return_value = None
     monkeypatch.setattr(main, "user_repository", user_repo)
 
@@ -265,13 +269,13 @@ async def test_debug_memory_retrieve_returns_404_when_companion_not_found(monkey
     mock_settings = mock.Mock()
     mock_settings.memory.debug_endpoint_enabled = True
     monkeypatch.setattr(main, "settings", mock_settings)
-    monkeypatch.setattr(main, "memory_service", mock.Mock())
+    monkeypatch.setattr(main, "memory_service", mock.create_autospec(MemoryService, instance=True))
 
-    user_repo = mock.Mock()
+    user_repo = mock.create_autospec(SQLiteUserRepository, instance=True)
     user_repo.find_by_email.return_value = sample_user
     monkeypatch.setattr(main, "user_repository", user_repo)
 
-    companion_repo = mock.Mock()
+    companion_repo = mock.create_autospec(SQLiteAICompanionRepository, instance=True)
     companion_repo.find_by_id.return_value = None
     monkeypatch.setattr(main, "ai_companion_repository", companion_repo)
 
@@ -286,24 +290,23 @@ async def test_debug_memory_retrieve_returns_404_when_companion_not_found(monkey
 async def test_debug_memory_retrieve_success(monkeypatch, sample_user):
     mock_settings = mock.Mock()
     mock_settings.memory.debug_endpoint_enabled = True
-    mock_settings.memory.retrieval_top_k = 5
     monkeypatch.setattr(main, "settings", mock_settings)
 
-    user_repo = mock.Mock()
+    user_repo = mock.create_autospec(SQLiteUserRepository, instance=True)
     user_repo.find_by_email.return_value = sample_user
     monkeypatch.setattr(main, "user_repository", user_repo)
 
-    companion_repo = mock.Mock()
+    companion_repo = mock.create_autospec(SQLiteAICompanionRepository, instance=True)
     mock_companion = mock.Mock(id=99, user_id=sample_user.id)
     companion_repo.find_by_id.return_value = mock_companion
     monkeypatch.setattr(main, "ai_companion_repository", companion_repo)
 
-    memory_service = mock.Mock()
+    memory_service = mock.create_autospec(MemoryService, instance=True)
     from src.memory.schemas import MemorySearchResult
     mock_result = MemorySearchResult(
         memory_id=1, memory_type="fact", content="test", canonical_key="key", score=0.9, source="semantic"
     )
-    memory_service.retrieve_memories = mock.AsyncMock(return_value=[mock_result])
+    memory_service.retrieve_memories.return_value = [mock_result]
     monkeypatch.setattr(main, "memory_service", memory_service)
 
     from src.memory.schemas import DebugMemoryRetrieveRequest
@@ -314,6 +317,36 @@ async def test_debug_memory_retrieve_success(monkeypatch, sample_user):
     assert response.ai_companion_id == 99
     assert len(response.memories) == 1
     assert response.memories[0].memory_id == 1
+    memory_service.retrieve_memories.assert_awaited_once_with(
+        user_id=sample_user.id, ai_companion_id=mock_companion.id, query="hello"
+    )
+
+@pytest.mark.anyio
+async def test_debug_memory_retrieve_success_empty_memories(monkeypatch, sample_user):
+    mock_settings = mock.Mock()
+    mock_settings.memory.debug_endpoint_enabled = True
+    monkeypatch.setattr(main, "settings", mock_settings)
+
+    user_repo = mock.create_autospec(SQLiteUserRepository, instance=True)
+    user_repo.find_by_email.return_value = sample_user
+    monkeypatch.setattr(main, "user_repository", user_repo)
+
+    companion_repo = mock.create_autospec(SQLiteAICompanionRepository, instance=True)
+    mock_companion = mock.Mock(id=99, user_id=sample_user.id)
+    companion_repo.find_by_id.return_value = mock_companion
+    monkeypatch.setattr(main, "ai_companion_repository", companion_repo)
+
+    memory_service = mock.create_autospec(MemoryService, instance=True)
+    memory_service.retrieve_memories.return_value = []
+    monkeypatch.setattr(main, "memory_service", memory_service)
+
+    from src.memory.schemas import DebugMemoryRetrieveRequest
+    payload = DebugMemoryRetrieveRequest(user_mail_id=sample_user.email, ai_companion_id=99, user_message="hello")
+    response = await main.debug_memory_retrieve(payload)
+
+    assert response.user_mail_id == sample_user.email
+    assert response.ai_companion_id == 99
+    assert len(response.memories) == 0
     memory_service.retrieve_memories.assert_awaited_once_with(
         user_id=sample_user.id, ai_companion_id=mock_companion.id, query="hello"
     )

--- a/tests/unit/backend/test_main_endpoints.py
+++ b/tests/unit/backend/test_main_endpoints.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+from fastapi.testclient import TestClient
 
 import main
 from src.auth.exceptions import UserAlreadyExistsError
@@ -222,3 +223,97 @@ async def test_companion_endpoints_delegate_to_service(monkeypatch):
     assert await main.generate_ai_companion(generate_payload) is generate_response
     assert main.list_ai_companions("user@example.com") == ["one"]
     assert main.get_ai_companion(3) == "ai-companion"
+
+
+@pytest.mark.anyio
+async def test_debug_memory_retrieve_returns_404_when_disabled(monkeypatch):
+    mock_settings = mock.Mock()
+    mock_settings.memory.debug_endpoint_enabled = False
+    monkeypatch.setattr(main, "settings", mock_settings)
+    monkeypatch.setattr(main, "memory_service", mock.Mock())
+
+    from src.memory.schemas import DebugMemoryRetrieveRequest
+    payload = DebugMemoryRetrieveRequest(user_mail_id="user@example.com", ai_companion_id=1, user_message="hello")
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        await main.debug_memory_retrieve(payload)
+    
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_debug_memory_retrieve_returns_404_when_user_not_found(monkeypatch):
+    mock_settings = mock.Mock()
+    mock_settings.memory.debug_endpoint_enabled = True
+    monkeypatch.setattr(main, "settings", mock_settings)
+    monkeypatch.setattr(main, "memory_service", mock.Mock())
+
+    user_repo = mock.Mock()
+    user_repo.find_by_email.return_value = None
+    monkeypatch.setattr(main, "user_repository", user_repo)
+
+    from src.memory.schemas import DebugMemoryRetrieveRequest
+    payload = DebugMemoryRetrieveRequest(user_mail_id="user@example.com", ai_companion_id=1, user_message="hello")
+
+    with pytest.raises(CompanionNotFoundError, match="User not found"):
+        await main.debug_memory_retrieve(payload)
+
+
+@pytest.mark.anyio
+async def test_debug_memory_retrieve_returns_404_when_companion_not_found(monkeypatch, sample_user):
+    mock_settings = mock.Mock()
+    mock_settings.memory.debug_endpoint_enabled = True
+    monkeypatch.setattr(main, "settings", mock_settings)
+    monkeypatch.setattr(main, "memory_service", mock.Mock())
+
+    user_repo = mock.Mock()
+    user_repo.find_by_email.return_value = sample_user
+    monkeypatch.setattr(main, "user_repository", user_repo)
+
+    companion_repo = mock.Mock()
+    companion_repo.get_latest_ai_companion.return_value = None
+    monkeypatch.setattr(main, "ai_companion_repository", companion_repo)
+
+    from src.memory.schemas import DebugMemoryRetrieveRequest
+    payload = DebugMemoryRetrieveRequest(user_mail_id=sample_user.email, ai_companion_id=99, user_message="hello")
+
+    with pytest.raises(CompanionNotFoundError, match="Companion 99 not found"):
+        await main.debug_memory_retrieve(payload)
+
+
+@pytest.mark.anyio
+async def test_debug_memory_retrieve_success(monkeypatch, sample_user):
+    mock_settings = mock.Mock()
+    mock_settings.memory.debug_endpoint_enabled = True
+    mock_settings.memory.retrieval_top_k = 5
+    monkeypatch.setattr(main, "settings", mock_settings)
+
+    user_repo = mock.Mock()
+    user_repo.find_by_email.return_value = sample_user
+    monkeypatch.setattr(main, "user_repository", user_repo)
+
+    companion_repo = mock.Mock()
+    mock_companion = mock.Mock(id=99)
+    companion_repo.get_latest_ai_companion.return_value = mock_companion
+    monkeypatch.setattr(main, "ai_companion_repository", companion_repo)
+
+    memory_service = mock.Mock()
+    from src.memory.schemas import MemorySearchResult
+    mock_result = MemorySearchResult(
+        memory_id=1, memory_type="fact", content="test", canonical_key="key", score=0.9, source="semantic"
+    )
+    memory_service.retrieve_memories = mock.AsyncMock(return_value=[mock_result])
+    monkeypatch.setattr(main, "memory_service", memory_service)
+
+    from src.memory.schemas import DebugMemoryRetrieveRequest
+    payload = DebugMemoryRetrieveRequest(user_mail_id=sample_user.email, ai_companion_id=99, user_message="hello")
+    response = await main.debug_memory_retrieve(payload)
+
+    assert response.user_mail_id == sample_user.email
+    assert response.ai_companion_id == 99
+    assert len(response.memories) == 1
+    assert response.memories[0].memory_id == 1
+    memory_service.retrieve_memories.assert_awaited_once_with(
+        user_id=sample_user.id, ai_companion_id=mock_companion.id, query_text="hello", limit=5
+    )


### PR DESCRIPTION
Resolves #43. Adds POST /debug/memory/retrieve endpoint guarded by MISTRIA_MEMORY_DEBUG_ENDPOINT_ENABLED. Includes full ownership validation and tests.