### PR TITLE
feat: Add memory backfill CLI script

### DIFF
--- a/scripts/backfill_memory.py
+++ b/scripts/backfill_memory.py
@@ -1,0 +1,267 @@
+"""Backfill memory extraction for existing chat history."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from dataclasses import dataclass, field
+
+from src.Logging import get_logger
+from src.backend.runtime import InferenceRuntimeFactory
+from src.config import settings
+from src.memory.embeddings import LocalEmbeddingProvider
+from src.memory.extraction import MemoryExtractionService
+from src.memory.service import MemoryService
+from src.memory.vector_store import QdrantVectorStore
+from src.storage.database import SQLiteDatabase
+from src.storage.memory_repository import SQLiteMemoryRepository
+from src.storage.repositories import SQLiteUserRepository
+
+logger = get_logger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the backfill script."""
+    parser = argparse.ArgumentParser(
+        description="Backfill memory extraction from existing chat history.",
+    )
+    parser.add_argument(
+        "--user-email",
+        default=None,
+        help="Limit backfill to a single user by email address.",
+    )
+    parser.add_argument(
+        "--ai-companion-id",
+        type=int,
+        default=None,
+        help="Limit backfill to a single AI companion ID.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of user messages to process.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Extract candidates but do not persist them.",
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Abort the entire run on first extraction failure.",
+    )
+    return parser.parse_args(argv)
+
+
+@dataclass
+class BackfillStats:
+    """Accumulated counters for the backfill run."""
+
+    scanned: int = 0
+    skipped: int = 0
+    extracted: int = 0
+    stored: int = 0
+    failed: int = 0
+
+
+def scan_messages(
+    database: SQLiteDatabase,
+    *,
+    user_id: int | None = None,
+    ai_companion_id: int | None = None,
+    limit: int | None = None,
+) -> list[dict]:
+    """Query user messages joined with their conversation scope.
+
+    Returns a list of dicts with keys:
+        message_id, conversation_id, user_id, ai_companion_id, content
+    """
+    clauses = ["m.role = 'user'", "c.ai_companion_id IS NOT NULL"]
+    params: list[object] = []
+
+    if user_id is not None:
+        clauses.append("c.user_id = ?")
+        params.append(user_id)
+
+    if ai_companion_id is not None:
+        clauses.append("c.ai_companion_id = ?")
+        params.append(ai_companion_id)
+
+    where = " AND ".join(clauses)
+    query = f"""
+        SELECT
+            m.id          AS message_id,
+            c.id          AS conversation_id,
+            c.user_id     AS user_id,
+            c.ai_companion_id AS ai_companion_id,
+            m.content     AS content
+        FROM messages m
+        JOIN conversations c ON c.id = m.conversation_id
+        WHERE {where}
+        ORDER BY m.created_at ASC, m.id ASC
+    """
+
+    if limit is not None:
+        query += " LIMIT ?"
+        params.append(limit)
+
+    with database.connection() as connection:
+        rows = connection.execute(query, params).fetchall()
+
+    return [dict(row) for row in rows]
+
+
+def load_processed_message_ids(database: SQLiteDatabase) -> set[int]:
+    """Return the set of message IDs that already have memory candidates."""
+    with database.connection() as connection:
+        rows = connection.execute(
+            "SELECT DISTINCT source_message_id FROM memories WHERE source_message_id IS NOT NULL"
+        ).fetchall()
+    return {row["source_message_id"] for row in rows}
+
+
+async def run_backfill(args: argparse.Namespace) -> BackfillStats:
+    """Execute the backfill run with the given CLI arguments."""
+    stats = BackfillStats()
+
+    # 1. Initialize infrastructure
+    database = SQLiteDatabase(settings.storage.sqlite_path)
+    database.initialize()
+
+    user_repository = SQLiteUserRepository(database)
+    memory_repository = SQLiteMemoryRepository(database)
+
+    runtime = InferenceRuntimeFactory.create(
+        settings.chat, settings.inference, settings.secrets,
+    )
+    await runtime.startup()
+
+    extraction_service = MemoryExtractionService(runtime)
+
+    # Memory service and its dependencies (only needed for non-dry-run)
+    memory_service: MemoryService | None = None
+    if not args.dry_run:
+        embedding_provider = LocalEmbeddingProvider(settings.memory.embedding_model_name)
+        vector_store = QdrantVectorStore(
+            url=settings.memory.qdrant_url,
+            collection_name=settings.memory.qdrant_collection,
+            enabled=settings.memory.enabled,
+        )
+        dimension = embedding_provider.get_dimension()
+        vector_store.bootstrap_collection(dimension)
+        memory_service = MemoryService(
+            config=settings.memory,
+            repository=memory_repository,
+            vector_store=vector_store,
+            embedding_provider=embedding_provider,
+        )
+
+    try:
+        # 2. Resolve optional user filter
+        user_id_filter: int | None = None
+        if args.user_email:
+            user = user_repository.find_by_email(args.user_email)
+            if not user:
+                logger.error("User not found for email=%s", args.user_email)
+                return stats
+            user_id_filter = user.id
+            logger.info("Filtering to user_id=%d email=%s", user.id, args.user_email)
+
+        # 3. Scan messages
+        messages = scan_messages(
+            database,
+            user_id=user_id_filter,
+            ai_companion_id=args.ai_companion_id,
+            limit=args.limit,
+        )
+        logger.info("Scanned %d user messages from chat history.", len(messages))
+
+        # 4. Load already-processed message IDs for skip logic
+        processed_ids = load_processed_message_ids(database)
+        logger.info("Found %d messages already linked to memories.", len(processed_ids))
+
+        # 5. Process each message
+        for msg in messages:
+            stats.scanned += 1
+            message_id = msg["message_id"]
+
+            if message_id in processed_ids:
+                stats.skipped += 1
+                continue
+
+            try:
+                candidates = await extraction_service.extract_memories(
+                    user_id=msg["user_id"],
+                    ai_companion_id=msg["ai_companion_id"],
+                    conversation_id=msg["conversation_id"],
+                    message_id=message_id,
+                    message_content=msg["content"],
+                )
+
+                stats.extracted += len(candidates)
+
+                if candidates and memory_service and not args.dry_run:
+                    stored_ids = await memory_service.store_memories(
+                        user_id=msg["user_id"],
+                        ai_companion_id=msg["ai_companion_id"],
+                        conversation_id=msg["conversation_id"],
+                        message_id=message_id,
+                        extracted_memories=candidates,
+                    )
+                    stats.stored += len(stored_ids)
+
+                if args.dry_run and candidates:
+                    logger.info(
+                        "[DRY RUN] message_id=%d would produce %d candidates",
+                        message_id, len(candidates),
+                    )
+
+            except Exception as e:
+                stats.failed += 1
+                logger.error(
+                    "Failed to process message_id=%d conversation_id=%d: %s",
+                    message_id, msg["conversation_id"], e,
+                )
+                if args.fail_fast:
+                    raise
+
+    finally:
+        await runtime.shutdown()
+
+    return stats
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the backfill script."""
+    args = parse_args(argv)
+
+    mode = "DRY RUN" if args.dry_run else "LIVE"
+    logger.info(
+        "Starting memory backfill mode=%s user_email=%s ai_companion_id=%s limit=%s fail_fast=%s",
+        mode, args.user_email, args.ai_companion_id, args.limit, args.fail_fast,
+    )
+
+    stats = asyncio.run(run_backfill(args))
+
+    summary = (
+        f"\n{'=' * 50}\n"
+        f"  Memory Backfill Summary ({mode})\n"
+        f"{'=' * 50}\n"
+        f"  Messages scanned:  {stats.scanned}\n"
+        f"  Messages skipped:  {stats.skipped}\n"
+        f"  Candidates found:  {stats.extracted}\n"
+        f"  Memories stored:   {stats.stored}\n"
+        f"  Failures:          {stats.failed}\n"
+        f"{'=' * 50}\n"
+    )
+    print(summary)
+
+    if stats.failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/service.py
+++ b/src/backend/service.py
@@ -107,22 +107,10 @@ class ChatService:
 
                 if memories:
                     memory_block = render_memory_prompt(memories)
-                    logger.debug(
-                        "Retrieved %d memories for conversation_id=%s",
-                        len(memories),
-                        conversation.id
+                    logger.info(
+                        "Prompt injection: injecting %d memories into system prompt conversation_id=%s",
+                        len(memories), conversation.id,
                     )
-                    for mem in memories:
-                        if self.memory_service.config.raw_content_logging_enabled:
-                            logger.debug(
-                                "Memory retrieved: id=%s, score=%.4f, type=%s, content=%r",
-                                mem.memory_id, mem.score, mem.memory_type, mem.content
-                            )
-                        else:
-                            logger.debug(
-                                "Memory retrieved: id=%s, score=%.4f, type=%s",
-                                mem.memory_id, mem.score, mem.memory_type
-                            )
             except Exception as e:
                 logger.error("Memory retrieval failed (falling back to normal chat): %s", e)
 

--- a/src/memory/extraction.py
+++ b/src/memory/extraction.py
@@ -101,7 +101,9 @@ class MemoryExtractionService:
 
         except ValidationError as e:
             logger.error(
-                "Extraction failed (validation) user_id=%d companion_id=%d conversation_id=%d message_id=%d: %s",
-                user_id, ai_companion_id, conversation_id, message_id, e,
+                "Extraction failed (validation) user_id=%d companion_id=%d conversation_id=%d message_id=%d errors=%d",
+                user_id, ai_companion_id, conversation_id, message_id, e.error_count(),
             )
+            if settings.memory.raw_content_logging_enabled:
+                logger.debug("Validation error details: %s", e)
             return []

--- a/src/memory/extraction.py
+++ b/src/memory/extraction.py
@@ -50,6 +50,10 @@ class MemoryExtractionService:
             return []
 
         if not message_content or not message_content.strip():
+            logger.debug(
+                "Extraction skipped (empty message) user_id=%d companion_id=%d conversation_id=%d message_id=%d",
+                user_id, ai_companion_id, conversation_id, message_id,
+            )
             return []
 
         logger.info(
@@ -81,16 +85,23 @@ class MemoryExtractionService:
             result = MemoryExtractionResult.model_validate_json(output_text.strip())
             
             valid_memories = [memory for memory in result.memories if memory.should_remember]
-            
+
+            logger.info(
+                "Extraction completed user_id=%d companion_id=%d conversation_id=%d message_id=%d candidates=%d",
+                user_id, ai_companion_id, conversation_id, message_id, len(valid_memories),
+            )
             if settings.memory.raw_content_logging_enabled:
                 for idx, memory in enumerate(valid_memories):
                     logger.debug(
-                        "Extracted candidate %d: type=%s key=%s content='%s' reason='%s'", 
-                        idx, memory.memory_type, memory.canonical_key, memory.content, memory.reason
+                        "Extracted candidate %d: type=%s key=%s content=%r reason=%r",
+                        idx, memory.memory_type, memory.canonical_key, memory.content, memory.reason,
                     )
-            
+
             return valid_memories
 
         except ValidationError as e:
-            logger.error("Malformed JSON or schema validation error during memory extraction: %s", e)
+            logger.error(
+                "Extraction failed (validation) user_id=%d companion_id=%d conversation_id=%d message_id=%d: %s",
+                user_id, ai_companion_id, conversation_id, message_id, e,
+            )
             return []

--- a/src/memory/service.py
+++ b/src/memory/service.py
@@ -100,11 +100,31 @@ class MemoryService:
                 new_id = new_record.id
                 stored_ids.append(new_id)
 
-                if existing:
+                if self.config.raw_content_logging_enabled:
                     logger.info(
-                        "Conflict detected for key '%s'. Superseding memory %d with %d",
-                        candidate.canonical_key, existing.id, new_id
+                        "Memory created id=%d user_id=%d companion_id=%d type=%s key=%s content=%r",
+                        new_id, user_id, ai_companion_id, candidate.memory_type,
+                        candidate.canonical_key, candidate.content,
                     )
+                else:
+                    logger.info(
+                        "Memory created id=%d user_id=%d companion_id=%d type=%s key=%s",
+                        new_id, user_id, ai_companion_id, candidate.memory_type,
+                        candidate.canonical_key,
+                    )
+
+                if existing:
+                    if self.config.raw_content_logging_enabled:
+                        logger.info(
+                            "Memory superseded old_id=%d new_id=%d key=%s old_content=%r new_content=%r",
+                            existing.id, new_id, candidate.canonical_key,
+                            existing.content, candidate.content,
+                        )
+                    else:
+                        logger.info(
+                            "Memory superseded old_id=%d new_id=%d key=%s",
+                            existing.id, new_id, candidate.canonical_key,
+                        )
                     # Mark old as superseded in SQLite
                     await asyncio.to_thread(
                         self.repository.supersede,
@@ -163,6 +183,13 @@ class MemoryService:
         """
         if not self.config.enabled:
             return []
+
+        logger.info(
+            "Retrieval started user_id=%d companion_id=%d",
+            user_id, ai_companion_id,
+        )
+        if self.config.raw_content_logging_enabled:
+            logger.debug("Retrieval query content=%r", query)
 
         # 1. Semantic Search (Qdrant)
         semantic_results = []
@@ -268,6 +295,17 @@ class MemoryService:
                 await asyncio.to_thread(self.repository.mark_retrieved, res.memory_id)
             except Exception as e:
                 logger.warning("Failed to mark memory %d as retrieved: %s", res.memory_id, e)
+
+        logger.info(
+            "Retrieval completed user_id=%d companion_id=%d results=%d",
+            user_id, ai_companion_id, len(top_results),
+        )
+        if self.config.raw_content_logging_enabled:
+            for res in top_results:
+                logger.debug(
+                    "Retrieved memory id=%d score=%.4f source=%s type=%s content=%r",
+                    res.memory_id, res.score, res.source, res.memory_type, res.content,
+                )
 
         return top_results
 

--- a/tests/unit/memory/test_memory_service.py
+++ b/tests/unit/memory/test_memory_service.py
@@ -308,3 +308,130 @@ async def test_retrieve_memories_vector_failure_fallback(memory_service, mock_re
     assert results[0].memory_id == 10
     assert results[0].source == "keyword"
 
+
+@pytest.mark.anyio
+async def test_store_memories_logs_raw_content_when_enabled(
+    mock_repo, mock_vector_store, mock_embeddings, caplog,
+):
+    """Test that raw memory content appears in logs when flag is enabled."""
+    config = Memory(enabled=True, raw_content_logging_enabled=True)
+    service = MemoryService(
+        config=config, repository=mock_repo,
+        vector_store=mock_vector_store, embedding_provider=mock_embeddings,
+    )
+    candidate = MemoryExtraction(
+        should_remember=True, memory_type="fact", canonical_key="user_job",
+        content="User is a developer.", importance=3, confidence=0.9,
+        reason="Stated.",
+    )
+    mock_repo.find_active_by_canonical_key.return_value = None
+    mock_repo.create_memory.return_value = mock.Mock(id=10)
+
+    import logging
+    mistria_logger = logging.getLogger("mistria")
+    mistria_logger.propagate = True
+    try:
+        with caplog.at_level(logging.DEBUG, logger="mistria"):
+            await service.store_memories(
+                user_id=1, ai_companion_id=2, conversation_id=10,
+                message_id=202, extracted_memories=[candidate],
+            )
+
+        assert any("User is a developer." in rec.message for rec in caplog.records)
+    finally:
+        mistria_logger.propagate = False
+
+
+@pytest.mark.anyio
+async def test_store_memories_suppresses_raw_content_when_disabled(
+    mock_repo, mock_vector_store, mock_embeddings, caplog,
+):
+    """Test that raw memory content does NOT appear in logs when flag is disabled."""
+    config = Memory(enabled=True, raw_content_logging_enabled=False)
+    service = MemoryService(
+        config=config, repository=mock_repo,
+        vector_store=mock_vector_store, embedding_provider=mock_embeddings,
+    )
+    candidate = MemoryExtraction(
+        should_remember=True, memory_type="fact", canonical_key="user_job",
+        content="User is a developer.", importance=3, confidence=0.9,
+        reason="Stated.",
+    )
+    mock_repo.find_active_by_canonical_key.return_value = None
+    mock_repo.create_memory.return_value = mock.Mock(id=10)
+
+    import logging
+    mistria_logger = logging.getLogger("mistria")
+    mistria_logger.propagate = True
+    try:
+        with caplog.at_level(logging.DEBUG, logger="mistria"):
+            await service.store_memories(
+                user_id=1, ai_companion_id=2, conversation_id=10,
+                message_id=202, extracted_memories=[candidate],
+            )
+
+        assert not any("User is a developer." in rec.message for rec in caplog.records)
+    finally:
+        mistria_logger.propagate = False
+
+
+@pytest.mark.anyio
+async def test_retrieve_memories_logs_raw_content_when_enabled(
+    mock_repo, mock_vector_store, mock_embeddings, caplog,
+):
+    """Test that retrieved memory content appears in logs when flag is enabled."""
+    config = Memory(enabled=True, raw_content_logging_enabled=True)
+    service = MemoryService(
+        config=config, repository=mock_repo,
+        vector_store=mock_vector_store, embedding_provider=mock_embeddings,
+    )
+    record = mock.Mock(
+        spec=MemoryRecord, id=10, user_id=1, ai_companion_id=2, status="active",
+        importance=3, confidence=1.0, updated_at=datetime.now(timezone.utc).isoformat(),
+        memory_type="fact", content="Secret info", canonical_key="secret",
+    )
+    mock_vector_store.search.return_value = []
+    mock_repo.keyword_search.return_value = [record]
+
+    import logging
+    mistria_logger = logging.getLogger("mistria")
+    mistria_logger.propagate = True
+    try:
+        with caplog.at_level(logging.DEBUG, logger="mistria"):
+            await service.retrieve_memories(user_id=1, ai_companion_id=2, query="test")
+
+        assert any("Secret info" in rec.message for rec in caplog.records)
+    finally:
+        mistria_logger.propagate = False
+
+
+@pytest.mark.anyio
+async def test_retrieve_memories_suppresses_raw_content_when_disabled(
+    mock_repo, mock_vector_store, mock_embeddings, caplog,
+):
+    """Test that retrieved memory content does NOT appear in logs when flag is disabled."""
+    config = Memory(enabled=True, raw_content_logging_enabled=False)
+    service = MemoryService(
+        config=config, repository=mock_repo,
+        vector_store=mock_vector_store, embedding_provider=mock_embeddings,
+    )
+    record = mock.Mock(
+        spec=MemoryRecord, id=10, user_id=1, ai_companion_id=2, status="active",
+        importance=3, confidence=1.0, updated_at=datetime.now(timezone.utc).isoformat(),
+        memory_type="fact", content="Secret info", canonical_key="secret",
+    )
+    mock_vector_store.search.return_value = []
+    mock_repo.keyword_search.return_value = [record]
+
+    import logging
+    mistria_logger = logging.getLogger("mistria")
+    mistria_logger.propagate = True
+    try:
+        with caplog.at_level(logging.DEBUG, logger="mistria"):
+            await service.retrieve_memories(user_id=1, ai_companion_id=2, query="test")
+
+        assert not any("Secret info" in rec.message for rec in caplog.records)
+    finally:
+        mistria_logger.propagate = False
+
+

--- a/tests/unit/scripts/test_backfill_memory.py
+++ b/tests/unit/scripts/test_backfill_memory.py
@@ -1,0 +1,345 @@
+"""Unit tests for the memory backfill script."""
+
+from __future__ import annotations
+
+import argparse
+from unittest import mock
+
+import pytest
+
+from scripts.backfill_memory import (
+    BackfillStats,
+    load_processed_message_ids,
+    parse_args,
+    run_backfill,
+    scan_messages,
+)
+from src.storage.database import SQLiteDatabase
+
+
+@pytest.fixture
+def tmp_database(tmp_path):
+    """Create a temporary SQLite database with the full schema."""
+    db_path = str(tmp_path / "test.db")
+    database = SQLiteDatabase(db_path)
+    database.initialize()
+
+    # Seed a user, companion, conversation, and messages
+    with database.connection() as conn:
+        conn.execute(
+            "INSERT INTO users (id, email, name) VALUES (1, 'alice@example.com', 'Alice')"
+        )
+        conn.execute(
+            "INSERT INTO users (id, email, name) VALUES (2, 'bob@example.com', 'Bob')"
+        )
+        conn.execute(
+            "INSERT INTO ai_companion (id, user_id, title, description, gender, style, ethnicity, "
+            "eye_color, hair_style, hair_color, personality, voice, connection) "
+            "VALUES (10, 1, 'Mira', 'desc', 'Female', 'Anime', 'Asian', 'Brown', 'Long', 'Black', "
+            "'Playful', 'Calm', 'New Encounter')"
+        )
+        conn.execute(
+            "INSERT INTO ai_companion (id, user_id, title, description, gender, style, ethnicity, "
+            "eye_color, hair_style, hair_color, personality, voice, connection) "
+            "VALUES (20, 2, 'Kai', 'desc', 'Male', 'Real', 'European', 'Blue', 'Short', 'Blond', "
+            "'Intense', 'Deep', 'Old Friend')"
+        )
+        conn.execute(
+            "INSERT INTO conversations (id, user_id, ai_companion_id) VALUES (100, 1, 10)"
+        )
+        conn.execute(
+            "INSERT INTO conversations (id, user_id, ai_companion_id) VALUES (200, 2, 20)"
+        )
+        # Alice's messages
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, role, content) VALUES (1, 100, 'user', 'I love dogs.')"
+        )
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, role, content) VALUES (2, 100, 'assistant', 'Dogs are great!')"
+        )
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, role, content) VALUES (3, 100, 'user', 'I am a developer.')"
+        )
+        # Bob's messages
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, role, content) VALUES (4, 200, 'user', 'I like cats.')"
+        )
+        conn.commit()
+
+    return database
+
+
+def test_parse_args_reads_cli_arguments():
+    """Test that CLI arguments are parsed correctly."""
+    args = parse_args([
+        "--user-email", "alice@example.com",
+        "--ai-companion-id", "10",
+        "--limit", "5",
+        "--dry-run",
+        "--fail-fast",
+    ])
+    assert args.user_email == "alice@example.com"
+    assert args.ai_companion_id == 10
+    assert args.limit == 5
+    assert args.dry_run is True
+    assert args.fail_fast is True
+
+
+def test_parse_args_defaults():
+    """Test that defaults are correct when no arguments given."""
+    args = parse_args([])
+    assert args.user_email is None
+    assert args.ai_companion_id is None
+    assert args.limit is None
+    assert args.dry_run is False
+    assert args.fail_fast is False
+
+
+def test_scan_messages_returns_only_user_messages(tmp_database):
+    """Test that only role='user' messages are returned."""
+    messages = scan_messages(tmp_database)
+    assert len(messages) == 3
+    contents = [m["content"] for m in messages]
+    assert "Dogs are great!" not in contents  # assistant message excluded
+    assert "I love dogs." in contents
+    assert "I am a developer." in contents
+    assert "I like cats." in contents
+
+
+def test_scan_messages_filter_by_user_id(tmp_database):
+    """Test filtering by user_id."""
+    messages = scan_messages(tmp_database, user_id=1)
+    assert len(messages) == 2
+    assert all(m["user_id"] == 1 for m in messages)
+
+
+def test_scan_messages_filter_by_companion_id(tmp_database):
+    """Test filtering by ai_companion_id."""
+    messages = scan_messages(tmp_database, ai_companion_id=20)
+    assert len(messages) == 1
+    assert messages[0]["ai_companion_id"] == 20
+    assert messages[0]["content"] == "I like cats."
+
+
+def test_scan_messages_limit(tmp_database):
+    """Test that --limit caps the result count."""
+    messages = scan_messages(tmp_database, limit=2)
+    assert len(messages) == 2
+
+
+def test_load_processed_message_ids_empty(tmp_database):
+    """Test that no processed IDs are returned when memories table is empty."""
+    ids = load_processed_message_ids(tmp_database)
+    assert ids == set()
+
+
+def test_load_processed_message_ids_populated(tmp_database):
+    """Test that processed message IDs are returned."""
+    with tmp_database.connection() as conn:
+        conn.execute(
+            "INSERT INTO memories (user_id, ai_companion_id, source_message_id, memory_type, "
+            "canonical_key, content, importance, confidence) "
+            "VALUES (1, 10, 1, 'fact', 'likes_dogs', 'Likes dogs', 3, 0.9)"
+        )
+        conn.commit()
+
+    ids = load_processed_message_ids(tmp_database)
+    assert ids == {1}
+
+
+@pytest.mark.anyio
+async def test_dry_run_does_not_write_memories(tmp_database, monkeypatch):
+    """Test that dry-run mode does not persist any memories."""
+    args = argparse.Namespace(
+        user_email=None, ai_companion_id=None, limit=None,
+        dry_run=True, fail_fast=False,
+    )
+
+    # Patch settings and database
+    mock_settings = mock.Mock()
+    mock_settings.storage.sqlite_path = tmp_database.database_path
+    mock_settings.chat = mock.Mock()
+    mock_settings.inference = mock.Mock()
+    mock_settings.secrets = mock.Mock()
+    mock_settings.memory.extraction_enabled = True
+    mock_settings.memory.raw_content_logging_enabled = False
+    monkeypatch.setattr("scripts.backfill_memory.settings", mock_settings)
+
+    # Mock the runtime
+    mock_runtime = mock.AsyncMock()
+    mock_runtime.generate_text.return_value = '{"memories": []}'
+    monkeypatch.setattr(
+        "scripts.backfill_memory.InferenceRuntimeFactory.create",
+        mock.Mock(return_value=mock_runtime),
+    )
+
+    # Mock extraction_service.extract_memories to return empty
+    monkeypatch.setattr(
+        "scripts.backfill_memory.MemoryExtractionService",
+        lambda runtime: mock.Mock(
+            extract_memories=mock.AsyncMock(return_value=[]),
+        ),
+    )
+
+    stats = await run_backfill(args)
+
+    assert stats.scanned == 3
+    assert stats.stored == 0
+
+    # Verify no memories were written
+    with tmp_database.connection() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+    assert count == 0
+
+
+@pytest.mark.anyio
+async def test_skip_already_processed_messages(tmp_database, monkeypatch):
+    """Test that messages already linked to memories are skipped."""
+    # Pre-insert a memory for message_id=1
+    with tmp_database.connection() as conn:
+        conn.execute(
+            "INSERT INTO memories (user_id, ai_companion_id, source_message_id, memory_type, "
+            "canonical_key, content, importance, confidence) "
+            "VALUES (1, 10, 1, 'fact', 'likes_dogs', 'Likes dogs', 3, 0.9)"
+        )
+        conn.commit()
+
+    args = argparse.Namespace(
+        user_email=None, ai_companion_id=None, limit=None,
+        dry_run=True, fail_fast=False,
+    )
+
+    mock_settings = mock.Mock()
+    mock_settings.storage.sqlite_path = tmp_database.database_path
+    mock_settings.chat = mock.Mock()
+    mock_settings.inference = mock.Mock()
+    mock_settings.secrets = mock.Mock()
+    mock_settings.memory.extraction_enabled = True
+    mock_settings.memory.raw_content_logging_enabled = False
+    monkeypatch.setattr("scripts.backfill_memory.settings", mock_settings)
+
+    mock_runtime = mock.AsyncMock()
+    monkeypatch.setattr(
+        "scripts.backfill_memory.InferenceRuntimeFactory.create",
+        mock.Mock(return_value=mock_runtime),
+    )
+
+    mock_extract = mock.AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        "scripts.backfill_memory.MemoryExtractionService",
+        lambda runtime: mock.Mock(extract_memories=mock_extract),
+    )
+
+    stats = await run_backfill(args)
+
+    assert stats.scanned == 3
+    assert stats.skipped == 1  # message_id=1 was skipped
+    # extract_memories should only be called for the 2 non-skipped messages
+    assert mock_extract.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_fail_fast_aborts_on_first_failure(tmp_database, monkeypatch):
+    """Test that --fail-fast aborts the run on first extraction error."""
+    args = argparse.Namespace(
+        user_email=None, ai_companion_id=None, limit=None,
+        dry_run=True, fail_fast=True,
+    )
+
+    mock_settings = mock.Mock()
+    mock_settings.storage.sqlite_path = tmp_database.database_path
+    mock_settings.chat = mock.Mock()
+    mock_settings.inference = mock.Mock()
+    mock_settings.secrets = mock.Mock()
+    mock_settings.memory.extraction_enabled = True
+    mock_settings.memory.raw_content_logging_enabled = False
+    monkeypatch.setattr("scripts.backfill_memory.settings", mock_settings)
+
+    mock_runtime = mock.AsyncMock()
+    monkeypatch.setattr(
+        "scripts.backfill_memory.InferenceRuntimeFactory.create",
+        mock.Mock(return_value=mock_runtime),
+    )
+
+    # First call fails
+    mock_extract = mock.AsyncMock(side_effect=RuntimeError("LLM down"))
+    monkeypatch.setattr(
+        "scripts.backfill_memory.MemoryExtractionService",
+        lambda runtime: mock.Mock(extract_memories=mock_extract),
+    )
+
+    with pytest.raises(RuntimeError, match="LLM down"):
+        await run_backfill(args)
+
+
+@pytest.mark.anyio
+async def test_failure_without_fail_fast_continues(tmp_database, monkeypatch):
+    """Test that without --fail-fast, failures are counted but processing continues."""
+    args = argparse.Namespace(
+        user_email=None, ai_companion_id=None, limit=None,
+        dry_run=True, fail_fast=False,
+    )
+
+    mock_settings = mock.Mock()
+    mock_settings.storage.sqlite_path = tmp_database.database_path
+    mock_settings.chat = mock.Mock()
+    mock_settings.inference = mock.Mock()
+    mock_settings.secrets = mock.Mock()
+    mock_settings.memory.extraction_enabled = True
+    mock_settings.memory.raw_content_logging_enabled = False
+    monkeypatch.setattr("scripts.backfill_memory.settings", mock_settings)
+
+    mock_runtime = mock.AsyncMock()
+    monkeypatch.setattr(
+        "scripts.backfill_memory.InferenceRuntimeFactory.create",
+        mock.Mock(return_value=mock_runtime),
+    )
+
+    # All calls fail
+    mock_extract = mock.AsyncMock(side_effect=RuntimeError("LLM down"))
+    monkeypatch.setattr(
+        "scripts.backfill_memory.MemoryExtractionService",
+        lambda runtime: mock.Mock(extract_memories=mock_extract),
+    )
+
+    stats = await run_backfill(args)
+
+    assert stats.scanned == 3
+    assert stats.failed == 3
+    assert stats.extracted == 0
+
+
+@pytest.mark.anyio
+async def test_user_email_filter(tmp_database, monkeypatch):
+    """Test that --user-email filters correctly."""
+    args = argparse.Namespace(
+        user_email="alice@example.com", ai_companion_id=None, limit=None,
+        dry_run=True, fail_fast=False,
+    )
+
+    mock_settings = mock.Mock()
+    mock_settings.storage.sqlite_path = tmp_database.database_path
+    mock_settings.chat = mock.Mock()
+    mock_settings.inference = mock.Mock()
+    mock_settings.secrets = mock.Mock()
+    mock_settings.memory.extraction_enabled = True
+    mock_settings.memory.raw_content_logging_enabled = False
+    monkeypatch.setattr("scripts.backfill_memory.settings", mock_settings)
+
+    mock_runtime = mock.AsyncMock()
+    monkeypatch.setattr(
+        "scripts.backfill_memory.InferenceRuntimeFactory.create",
+        mock.Mock(return_value=mock_runtime),
+    )
+
+    mock_extract = mock.AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        "scripts.backfill_memory.MemoryExtractionService",
+        lambda runtime: mock.Mock(extract_memories=mock_extract),
+    )
+
+    stats = await run_backfill(args)
+
+    # Only Alice's 2 user messages should be processed
+    assert stats.scanned == 2
+    assert mock_extract.await_count == 2


### PR DESCRIPTION
Resolves #45.

Adds a CLI script to extract memories from historical chat messages.

**Key Features:**
- **Scan/Filter**: Scans messages table for ole='user' and filters by user_email or i_companion_id.
- **Skip Logic**: Automatically skips messages that already have associated memory candidates.
- **Dry Run**: Supports --dry-run to extract candidates without persisting to SQLite or Qdrant.
- **Fail Fast**: Supports --fail-fast to abort on the first extraction error.
- **Stats**: Prints a detailed summary of scanned, skipped, extracted, stored, and failed messages.

**Testing:**
- Comprehensive unit tests in 	ests/unit/scripts/test_backfill_memory.py using a temporary SQLite database and LLM stubs.
- Verified all 187 project tests pass.