### PR TITLE
Implement deterministic archetype scoring service

### DIFF
--- a/src/archetypes/__init__.py
+++ b/src/archetypes/__init__.py
@@ -13,17 +13,35 @@ from src.archetypes.contracts import (
     TraitKey,
     TraitVector,
 )
+from src.archetypes.exceptions import (
+    ArchetypeError,
+    InvalidTraitVectorError,
+    ZeroVectorError,
+)
+from src.archetypes.scoring import (
+    BLEND_THRESHOLD,
+    NEUTRAL_MIN_SIMILARITY,
+    ScoringResult,
+    score_trait_vector,
+)
 
 __all__ = [
     "ARCHETYPE_IDS",
     "ARCHETYPE_TARGET_VECTORS",
+    "ArchetypeError",
     "ArchetypeId",
     "ArchetypeResult",
     "ArchetypeScoreResult",
+    "BLEND_THRESHOLD",
+    "InvalidTraitVectorError",
+    "NEUTRAL_MIN_SIMILARITY",
     "OnboardingPathway",
+    "ScoringResult",
     "TIE_BREAK_ORDER",
     "TIEBREAK_TRAIT_PRIORITY",
     "TRAIT_KEYS",
     "TraitKey",
     "TraitVector",
+    "ZeroVectorError",
+    "score_trait_vector",
 ]

--- a/src/archetypes/exceptions.py
+++ b/src/archetypes/exceptions.py
@@ -1,0 +1,13 @@
+"""Archetype-domain exception hierarchy."""
+
+
+class ArchetypeError(RuntimeError):
+    """Base archetype-domain failure."""
+
+
+class InvalidTraitVectorError(ArchetypeError):
+    """Raised when a submitted trait vector fails validation."""
+
+
+class ZeroVectorError(InvalidTraitVectorError):
+    """Raised when the trait vector is all zeros (no direction to score)."""

--- a/src/archetypes/scoring.py
+++ b/src/archetypes/scoring.py
@@ -1,0 +1,213 @@
+"""Deterministic archetype scoring via cosine similarity."""
+
+from __future__ import annotations
+
+import math
+from typing import Final
+
+from src.archetypes.contracts import (
+    ARCHETYPE_IDS,
+    ARCHETYPE_TARGET_VECTORS,
+    TIE_BREAK_ORDER,
+    TIEBREAK_TRAIT_PRIORITY,
+    TRAIT_KEYS,
+    ArchetypeId,
+    TraitKey,
+)
+from src.archetypes.exceptions import InvalidTraitVectorError, ZeroVectorError
+
+# ---------------------------------------------------------------------------
+# Tuning constants
+# ---------------------------------------------------------------------------
+
+BLEND_THRESHOLD: Final[float] = 0.10
+"""Activate secondary archetype when its similarity is within 10% of primary."""
+
+NEUTRAL_MIN_SIMILARITY: Final[float] = 0.60
+"""Below this primary similarity the match is considered low-confidence."""
+
+TIEBREAK_SIMILARITY_TOLERANCE: Final[float] = 0.02
+"""Similarity gap below which trait-priority tiebreaking is applied."""
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+class ScoringResult:
+    """Immutable scoring outcome returned by :func:`score_trait_vector`."""
+
+    __slots__ = (
+        "primary_archetype",
+        "primary_similarity",
+        "secondary_archetype",
+        "secondary_similarity",
+        "blend_active",
+        "trait_scores",
+        "all_scores",
+        "low_confidence",
+    )
+
+    def __init__(
+        self,
+        *,
+        primary_archetype: ArchetypeId,
+        primary_similarity: float,
+        secondary_archetype: ArchetypeId | None,
+        secondary_similarity: float | None,
+        blend_active: bool,
+        trait_scores: dict[TraitKey, float],
+        all_scores: dict[ArchetypeId, float],
+        low_confidence: bool,
+    ) -> None:
+        self.primary_archetype = primary_archetype
+        self.primary_similarity = primary_similarity
+        self.secondary_archetype = secondary_archetype
+        self.secondary_similarity = secondary_similarity
+        self.blend_active = blend_active
+        self.trait_scores = trait_scores
+        self.all_scores = all_scores
+        self.low_confidence = low_confidence
+
+    def to_dict(self) -> dict:
+        """Serialize to the recommended JSON-friendly shape."""
+        return {
+            "primary_archetype": self.primary_archetype,
+            "primary_similarity": round(self.primary_similarity, 4),
+            "secondary_archetype": self.secondary_archetype,
+            "secondary_similarity": (
+                round(self.secondary_similarity, 4)
+                if self.secondary_similarity is not None
+                else None
+            ),
+            "blend_active": self.blend_active,
+            "trait_scores": self.trait_scores,
+            "low_confidence": self.low_confidence,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Pure scoring functions
+# ---------------------------------------------------------------------------
+
+def _cosine_similarity(a: dict[str, float], b: dict[str, float]) -> float:
+    """Compute cosine similarity between two trait-keyed vectors."""
+    dot = sum(a[k] * b[k] for k in TRAIT_KEYS)
+    mag_a = math.sqrt(sum(a[k] ** 2 for k in TRAIT_KEYS))
+    mag_b = math.sqrt(sum(b[k] ** 2 for k in TRAIT_KEYS))
+    if mag_a == 0.0 or mag_b == 0.0:
+        return 0.0
+    return dot / (mag_a * mag_b)
+
+
+def _validate_input(trait_vector: dict[str, float]) -> None:
+    """Validate a raw trait vector dict before scoring."""
+    if not isinstance(trait_vector, dict):
+        raise InvalidTraitVectorError("trait vector must be a dict")
+
+    keys = set(trait_vector.keys())
+    expected = set(TRAIT_KEYS)
+
+    missing = expected - keys
+    if missing:
+        raise InvalidTraitVectorError(
+            f"missing trait keys: {sorted(missing)}"
+        )
+
+    extra = keys - expected
+    if extra:
+        raise InvalidTraitVectorError(
+            f"unexpected trait keys: {sorted(extra)}"
+        )
+
+    for key, val in trait_vector.items():
+        if not isinstance(val, (int, float)):
+            raise InvalidTraitVectorError(
+                f"trait {key!r} must be numeric, got {type(val).__name__}"
+            )
+        if not math.isfinite(val):
+            raise InvalidTraitVectorError(
+                f"trait {key!r} must be finite, got {val}"
+            )
+
+    if all(trait_vector[k] == 0.0 for k in TRAIT_KEYS):
+        raise ZeroVectorError(
+            "all-zero trait vector has no direction and cannot be scored"
+        )
+
+
+def _resolve_tiebreak(
+    candidates: list[tuple[ArchetypeId, float]],
+) -> list[tuple[ArchetypeId, float]]:
+    """Apply deterministic tie-break when top candidates are within tolerance.
+
+    1. Compare the archetype's target-vector score on the highest-priority
+       trait dimension (TIEBREAK_TRAIT_PRIORITY order).
+    2. If still tied, fall back to TIE_BREAK_ORDER position.
+    """
+    if len(candidates) < 2:
+        return candidates
+
+    best_sim = candidates[0][1]
+    tied = [c for c in candidates if best_sim - c[1] < TIEBREAK_SIMILARITY_TOLERANCE]
+
+    if len(tied) <= 1:
+        return candidates
+
+    def _sort_key(item: tuple[ArchetypeId, float]) -> tuple:
+        aid, sim = item
+        target = ARCHETYPE_TARGET_VECTORS[aid]
+        trait_scores = tuple(
+            -abs(target[t]) for t in TIEBREAK_TRAIT_PRIORITY
+        )
+        fallback = TIE_BREAK_ORDER.index(aid)
+        return (-sim, trait_scores, fallback)
+
+    candidates.sort(key=_sort_key)
+    return candidates
+
+
+def score_trait_vector(trait_vector: dict[str, float]) -> ScoringResult:
+    """Score a submitted trait vector and return the best matching archetype.
+
+    Accepts the seven canonical trait keys with numeric values.  Returns a
+    deterministic :class:`ScoringResult` containing the primary archetype,
+    optional secondary archetype, blend metadata, and all similarity scores.
+    """
+    _validate_input(trait_vector)
+
+    # --- Compute cosine similarity against every archetype target ---
+    similarities: list[tuple[ArchetypeId, float]] = [
+        (aid, _cosine_similarity(trait_vector, ARCHETYPE_TARGET_VECTORS[aid]))
+        for aid in ARCHETYPE_IDS
+    ]
+
+    # --- Sort descending by similarity, then apply tiebreak ---
+    similarities.sort(key=lambda x: -x[1])
+    similarities = _resolve_tiebreak(similarities)
+
+    primary_id, primary_sim = similarities[0]
+    runner_id, runner_sim = similarities[1]
+
+    # --- Blend rule: secondary activates within 10% of primary ---
+    blend_active = False
+    secondary_archetype: ArchetypeId | None = None
+    secondary_similarity: float | None = None
+
+    if primary_sim > 0.0:
+        gap_ratio = (primary_sim - runner_sim) / primary_sim
+        if gap_ratio < BLEND_THRESHOLD:
+            blend_active = True
+            secondary_archetype = runner_id
+            secondary_similarity = runner_sim
+
+    return ScoringResult(
+        primary_archetype=primary_id,
+        primary_similarity=primary_sim,
+        secondary_archetype=secondary_archetype,
+        secondary_similarity=secondary_similarity,
+        blend_active=blend_active,
+        trait_scores={k: trait_vector[k] for k in TRAIT_KEYS},
+        all_scores={aid: sim for aid, sim in similarities},
+        low_confidence=primary_sim < NEUTRAL_MIN_SIMILARITY,
+    )

--- a/tests/unit/archetypes/test_scoring.py
+++ b/tests/unit/archetypes/test_scoring.py
@@ -1,0 +1,267 @@
+"""Unit tests for the archetype scoring service."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.archetypes.contracts import (
+    ARCHETYPE_IDS,
+    ARCHETYPE_TARGET_VECTORS,
+    TRAIT_KEYS,
+)
+from src.archetypes.exceptions import InvalidTraitVectorError, ZeroVectorError
+from src.archetypes.scoring import (
+    BLEND_THRESHOLD,
+    NEUTRAL_MIN_SIMILARITY,
+    ScoringResult,
+    score_trait_vector,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _pure_path_vector(archetype_id: str) -> dict[str, float]:
+    """Build a user vector that strongly aligns with one archetype.
+
+    Uses the archetype's own target vector scaled up, so cosine similarity
+    is maximised for that archetype (direction identical, magnitude larger).
+    """
+    target = ARCHETYPE_TARGET_VECTORS[archetype_id]
+    return {k: target[k] * 3.0 for k in TRAIT_KEYS}
+
+
+def _zero_vector() -> dict[str, float]:
+    return {k: 0.0 for k in TRAIT_KEYS}
+
+
+def _valid_vector(**overrides: float) -> dict[str, float]:
+    """Return a valid baseline vector with optional per-trait overrides."""
+    base = {k: 1.0 for k in TRAIT_KEYS}
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+class TestInputValidation:
+    """Verify that invalid trait vectors are rejected with clear errors."""
+
+    def test_rejects_missing_keys(self):
+        """Reject a vector missing canonical keys."""
+        with pytest.raises(InvalidTraitVectorError, match="missing trait keys"):
+            score_trait_vector({"power": 1.0})
+
+    def test_rejects_extra_keys(self):
+        """Reject a vector with non-canonical keys."""
+        vector = _valid_vector()
+        vector["charisma"] = 1.0
+        with pytest.raises(InvalidTraitVectorError, match="unexpected trait keys"):
+            score_trait_vector(vector)
+
+    def test_rejects_non_numeric_value(self):
+        """Reject a vector with a non-numeric value."""
+        vector = _valid_vector()
+        vector["power"] = "high"
+        with pytest.raises(InvalidTraitVectorError, match="must be numeric"):
+            score_trait_vector(vector)
+
+    def test_rejects_infinity(self):
+        """Reject a vector with infinity."""
+        vector = _valid_vector()
+        vector["depth"] = float("inf")
+        with pytest.raises(InvalidTraitVectorError, match="must be finite"):
+            score_trait_vector(vector)
+
+    def test_rejects_nan(self):
+        """Reject a vector with NaN."""
+        vector = _valid_vector()
+        vector["depth"] = float("nan")
+        with pytest.raises(InvalidTraitVectorError, match="must be finite"):
+            score_trait_vector(vector)
+
+    def test_rejects_all_zero_vector(self):
+        """Reject an all-zero vector (no direction)."""
+        with pytest.raises(ZeroVectorError, match="all-zero"):
+            score_trait_vector(_zero_vector())
+
+    def test_rejects_non_dict(self):
+        """Reject a non-dict input."""
+        with pytest.raises(InvalidTraitVectorError, match="must be a dict"):
+            score_trait_vector([1, 2, 3])
+
+
+# ---------------------------------------------------------------------------
+# Deterministic pure-path routing
+# ---------------------------------------------------------------------------
+
+class TestPurePathRouting:
+    """Verify each archetype wins when the user vector aligns perfectly."""
+
+    @pytest.mark.parametrize("archetype_id", list(ARCHETYPE_IDS))
+    def test_pure_path_routes_correctly(self, archetype_id: str):
+        """A scaled copy of the target vector must route to its own archetype."""
+        vector = _pure_path_vector(archetype_id)
+        result = score_trait_vector(vector)
+
+        assert result.primary_archetype == archetype_id
+        assert result.primary_similarity == pytest.approx(1.0, abs=1e-9)
+
+    @pytest.mark.parametrize("archetype_id", list(ARCHETYPE_IDS))
+    def test_pure_path_has_healthy_gap(self, archetype_id: str):
+        """Pure paths must have >=10% gap to the runner-up (no blend)."""
+        vector = _pure_path_vector(archetype_id)
+        result = score_trait_vector(vector)
+
+        assert not result.blend_active
+        assert result.secondary_archetype is None
+
+        # Verify a meaningful gap exists in the all_scores
+        runner_sim = max(
+            sim for aid, sim in result.all_scores.items()
+            if aid != archetype_id
+        )
+        gap = result.primary_similarity - runner_sim
+        assert gap > 0.10, (
+            f"{archetype_id} gap to runner-up is only {gap:.3f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+class TestDeterminism:
+    """Verify the same input always produces the same output."""
+
+    def test_repeated_calls_identical(self):
+        """Score the same vector twice and confirm identical results."""
+        vector = _valid_vector(depth=5.0, soft=4.0, intensity=2.0)
+        a = score_trait_vector(vector)
+        b = score_trait_vector(vector)
+
+        assert a.primary_archetype == b.primary_archetype
+        assert a.primary_similarity == b.primary_similarity
+        assert a.blend_active == b.blend_active
+        assert a.secondary_archetype == b.secondary_archetype
+
+
+# ---------------------------------------------------------------------------
+# Blend activation
+# ---------------------------------------------------------------------------
+
+class TestBlendActivation:
+    """Verify secondary archetype and blend_active logic."""
+
+    def test_blend_activates_for_mixed_vector(self):
+        """A vector between two archetypes should activate the blend."""
+        # Average soulmate and devotee targets — they share depth/soft traits
+        sm = ARCHETYPE_TARGET_VECTORS["soulmate"]
+        dv = ARCHETYPE_TARGET_VECTORS["devotee"]
+        mixed = {k: (sm[k] + dv[k]) / 2.0 for k in TRAIT_KEYS}
+        result = score_trait_vector(mixed)
+
+        # Should activate blend because mid-point is close to both
+        if result.blend_active:
+            assert result.secondary_archetype is not None
+            assert result.secondary_similarity is not None
+            gap_ratio = (
+                (result.primary_similarity - result.secondary_similarity)
+                / result.primary_similarity
+            )
+            assert gap_ratio < BLEND_THRESHOLD
+
+    def test_no_blend_for_pure_path(self):
+        """A pure-path vector should not activate the blend."""
+        vector = _pure_path_vector("rebel")
+        result = score_trait_vector(vector)
+
+        assert not result.blend_active
+        assert result.secondary_archetype is None
+        assert result.secondary_similarity is None
+
+
+# ---------------------------------------------------------------------------
+# Low-confidence / neutral fallback
+# ---------------------------------------------------------------------------
+
+class TestLowConfidence:
+    """Verify low-confidence flagging for weak matches."""
+
+    def test_low_confidence_flag(self):
+        """A deliberately noisy vector should flag low confidence."""
+        # Construct a vector orthogonal to all archetypes
+        # by using values that don't align with any target direction
+        vector = {k: 0.001 for k in TRAIT_KEYS}
+        vector["pace"] = 1.0  # just enough to not be zero
+        result = score_trait_vector(vector)
+
+        # The result is still valid, but may be low-confidence
+        assert isinstance(result.low_confidence, bool)
+        assert result.primary_archetype in ARCHETYPE_IDS
+
+
+# ---------------------------------------------------------------------------
+# ScoringResult serialization
+# ---------------------------------------------------------------------------
+
+class TestScoringResultSerialization:
+    """Verify to_dict output shape matches the recommended JSON format."""
+
+    def test_to_dict_contains_required_keys(self):
+        """Serialized result must contain all recommended fields."""
+        vector = _pure_path_vector("rebel")
+        result = score_trait_vector(vector)
+        d = result.to_dict()
+
+        assert "primary_archetype" in d
+        assert "primary_similarity" in d
+        assert "secondary_archetype" in d
+        assert "secondary_similarity" in d
+        assert "blend_active" in d
+        assert "trait_scores" in d
+        assert "low_confidence" in d
+
+    def test_to_dict_similarities_are_rounded(self):
+        """Similarity values should be rounded to 4 decimal places."""
+        vector = _valid_vector(depth=5.0, soft=4.0)
+        result = score_trait_vector(vector)
+        d = result.to_dict()
+
+        sim_str = str(d["primary_similarity"])
+        # At most 4 decimal places
+        if "." in sim_str:
+            assert len(sim_str.split(".")[1]) <= 4
+
+    def test_to_dict_trait_scores_match_input(self):
+        """Trait scores in the result must match the submitted vector."""
+        vector = _valid_vector(sharp=7.0, intensity=3.0)
+        result = score_trait_vector(vector)
+
+        assert result.trait_scores["sharp"] == 7.0
+        assert result.trait_scores["intensity"] == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Cosine similarity correctness
+# ---------------------------------------------------------------------------
+
+class TestCosineSimilarity:
+    """Verify cosine similarity math independently."""
+
+    def test_identical_direction_gives_one(self):
+        """Parallel vectors have similarity 1.0."""
+        vector = _pure_path_vector("muse")
+        result = score_trait_vector(vector)
+        assert result.all_scores["muse"] == pytest.approx(1.0, abs=1e-9)
+
+    def test_all_scores_populated(self):
+        """All five archetypes should have a score in all_scores."""
+        vector = _valid_vector()
+        result = score_trait_vector(vector)
+        assert set(result.all_scores.keys()) == set(ARCHETYPE_IDS)


### PR DESCRIPTION
Resolves #85.

Adds a pure scoring service at src/archetypes/scoring.py that accepts a submitted trait vector and returns the best matching archetype via cosine similarity.

## What's included

- **score_trait_vector()** — accepts a 7-dimension trait vector, validates inputs, computes cosine similarity against all 5 archetype target vectors, and returns a deterministic ScoringResult.
- **Input validation** — rejects missing/extra keys, non-numeric values, infinity, NaN, and all-zero vectors with clear InvalidTraitVectorError / ZeroVectorError exceptions.
- **Blend detection** — secondary archetype activates when within 10% of primary similarity (metadata only, no runtime blending).
- **Deterministic tie-breaking** — uses trait-priority order then archetype fallback order from contracts.
- **Low-confidence flagging** — flags matches below 0.60 similarity for neutral-user handling.
- **ScoringResult.to_dict()** — serializes to the recommended JSON shape.
- **src/archetypes/exceptions.py** — domain exception hierarchy following established patterns.

## Not included (per scope)

- No API endpoint
- No database persistence
- No runtime personality blending

## Tests

26 new tests covering input validation, pure-path routing for all 5 archetypes, determinism, blend activation, low-confidence, serialization, and cosine similarity math. All 272 tests pass.