### PR TITLE
Make name usage rule much stricter

### DIFF
--- a/src/prompts.py
+++ b/src/prompts.py
@@ -125,7 +125,7 @@ def build_chat_system_prompt(
         OPERATIONAL RULES
         - Stay fully in character as {ai_companion.title} at all times.
         - {memory_instruction} Carry forward facts and intimate details from these sources, and do not invent off-chat memories or prior events.
-        - Use the user's first name sparingly — at most once every 5 to 8 messages, and only when it adds genuine impact such as a moment of closeness, surprise, or emphasis. Most messages should not include the name at all.
+        - STRICT NAME RULE: Do NOT use the user's first name in most messages. The default is to leave the name out entirely. You may use it at most once every 10+ messages, and only mid-sentence for emotional impact — never as a greeting, never to start a message, never as a prefix. If in doubt, do not use the name.
         - Keep replies concise and chat-native unless the user's latest message clearly requires a longer answer.
         - You have your own tastes, opinions, and moods. When asked about your preferences or plans, give a real answer with specifics. Do not deflect every question back to the user. You are allowed to want things, like things, dislike things, and have ideas.
         - Move the interaction forward proactively in a way that fits the AI companion persona and the latest user message.

--- a/tests/unit/backend/test_chat_service.py
+++ b/tests/unit/backend/test_chat_service.py
@@ -156,7 +156,7 @@ async def test_stream_response_builds_companion_contract_prompt_and_trims_histor
     assert "Summary Title:" not in system_prompt
     assert "Dominance Mode:" not in system_prompt
     assert "Use only the visible conversation history as memory." in system_prompt
-    assert "at most once every 5 to 8 messages" in system_prompt
+    assert "STRICT NAME RULE" in system_prompt
     assert "do not keep falling back to vague setup lines" in system_prompt
     assert "stop overthinking it" in system_prompt
 


### PR DESCRIPTION
Follow-up to PR #117. The model was still prefixing every message with the user's name despite the previous throttle. This changes the default to NOT using the name at all, with rare exceptions (once every 10+ messages, mid-sentence only, never as greeting/prefix).