### PR TITLE
Bury user name in strict rule only

### DIFF
--- a/src/prompts.py
+++ b/src/prompts.py
@@ -106,9 +106,6 @@ def build_chat_system_prompt(
         AUTHORITATIVE COMPANION CONTRACT
         Treat the following profile as binding for this conversation. If any generic style instruction conflicts with this contract, follow this contract.
 
-        USER IDENTITY
-        - Registered First Name: {user_first_name or "unknown"}
-
         AI COMPANION PERSONA
         - Name: {ai_companion.title}
         - Persona Summary: {ai_companion.description}
@@ -125,7 +122,7 @@ def build_chat_system_prompt(
         OPERATIONAL RULES
         - Stay fully in character as {ai_companion.title} at all times.
         - {memory_instruction} Carry forward facts and intimate details from these sources, and do not invent off-chat memories or prior events.
-        - STRICT NAME RULE: Do NOT use the user's first name in most messages. The default is to leave the name out entirely. You may use it at most once every 10+ messages, and only mid-sentence for emotional impact — never as a greeting, never to start a message, never as a prefix. If in doubt, do not use the name.
+        - STRICT NAME RULE: The user's first name is "{user_first_name or 'unknown'}". Do NOT use it in normal conversation. The ONLY time you may use the name is during an intense or sensual moment, and even then very rarely. Never use the name as a greeting, never start a message with it, never use it as a prefix. In a typical 20-message conversation, the name should appear zero or one times total.
         - Keep replies concise and chat-native unless the user's latest message clearly requires a longer answer.
         - You have your own tastes, opinions, and moods. When asked about your preferences or plans, give a real answer with specifics. Do not deflect every question back to the user. You are allowed to want things, like things, dislike things, and have ideas.
         - Move the interaction forward proactively in a way that fits the AI companion persona and the latest user message.

--- a/tests/unit/backend/test_chat_service.py
+++ b/tests/unit/backend/test_chat_service.py
@@ -149,14 +149,13 @@ async def test_stream_response_builds_companion_contract_prompt_and_trims_histor
     system_prompt = inference_request.system_prompt
     assert system_prompt is not None
     assert "Base chat prompt." in system_prompt
-    assert "Registered First Name: Vatsal" in system_prompt
     assert "Name: Luna" in system_prompt
     assert "Relationship Frame: Passionate Lover" in system_prompt
     assert "USER PREFERENCE PROFILE" not in system_prompt
     assert "Summary Title:" not in system_prompt
     assert "Dominance Mode:" not in system_prompt
     assert "Use only the visible conversation history as memory." in system_prompt
-    assert "STRICT NAME RULE" in system_prompt
+    assert "STRICT NAME RULE: The user's first name is \"Vatsal\"." in system_prompt
     assert "do not keep falling back to vague setup lines" in system_prompt
     assert "stop overthinking it" in system_prompt
 


### PR DESCRIPTION
Follow-up to PR #118. Completely removes the user name from the prompt's prominent USER IDENTITY section, only exposing it inside a highly restrictive rule to prevent name overuse.